### PR TITLE
Frontend theme redesign: emerald and lime light mode, neutral dark glass, and condition-specific accents

### DIFF
--- a/docs/superpowers/plans/2026-04-30-frontend-theme-redesign.md
+++ b/docs/superpowers/plans/2026-04-30-frontend-theme-redesign.md
@@ -1,0 +1,482 @@
+# Frontend theme redesign implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship approved dark (neutral glass) and light (emerald + lime) themes across the Next.js frontend, remove indigo/violet/purple global chrome, preserve navbar orange cursor-follow behavior, and align pointer-driven glows with parent control colors.
+
+**Architecture:** Centralize appearance in `frontend/app/globals.css` OKLCH design tokens and shared `.glass*` / `.neon*` utilities; replace hardcoded Tailwind color classes and inline `rgba` in scoped components per `docs/superpowers/specs/2026-04-30-frontend-theme-design.md`. A small Node guard script enforces absence of the old indigo literal in the repo’s `frontend/` tree after the sweep.
+
+**Tech stack:** Next.js 15, React 19, Tailwind CSS v4 (`@import "tailwindcss"`), shadcn-style CSS variables, Framer Motion, Node.js for the guard script (no extra npm deps).
+
+**Source spec:** `docs/superpowers/specs/2026-04-30-frontend-theme-design.md`
+
+---
+
+## File map (what changes)
+
+| File | Responsibility |
+|------|----------------|
+| `frontend/app/globals.css` | `:root` / `.dark` OKLCH tokens; `.glass`, `.glass-card`, `.glass-enhanced`, `.neon-glow*`, scrollbar rules |
+| `frontend/components/floating-navbar.tsx` | Idle pill border/shadow/logo/wordmark neutrals + brand greens; **do not** edit orange `glowPosition` layers’ colors, positions, blur radii, or `animate` transitions |
+| `frontend/app/page.tsx` | Hero, trust row, CTAs, Start Prediction cursor-follow + `boxShadow` |
+| `frontend/components/prediction-tabs.tsx` | Section chrome, tab card borders, hover gradient, pulse keyframes colors |
+| `frontend/components/contact-section.tsx` | Headings, icon tiles, submit button, decorative blurs, inline `border` styles |
+| `frontend/components/user-menu.tsx` | Subscription CTA strip gradients |
+| `frontend/components/subscription-modal.tsx` | Plan highlight gradients |
+| `frontend/components/auth-guard.tsx` | Bullet / accent copy colors |
+| `frontend/app/predict/heart/page.tsx` | Blobs, logo lockup, hero gradients, glass border (red family; drop pink where spec says) |
+| `frontend/app/predict/diabetes/page.tsx` | Teal/cyan identity; remove blue–violet |
+| `frontend/app/predict/parkinsons/page.tsx` | Forest/teal identity; remove purple/indigo/violet |
+| `frontend/app/predict/common-diseases/page.tsx` | Align greens with emerald if needed |
+| `frontend/components/forms/heart-prediction-form.tsx` | Replace purple/pink progress defaults with red/rose/neutral |
+| `frontend/components/forms/diabetes-prediction-form.tsx` | Replace purple/pink bars/icons with teal/cyan |
+| `frontend/components/forms/parkinsons-prediction-form.tsx` | Replace purple/indigo/pink with forest/teal |
+| `frontend/components/forms/common-diseases-prediction-form.tsx` | Replace purple/pink with green/emerald |
+| `frontend/scripts/verify-theme-palette.mjs` | CI-friendly guard: fail if forbidden indigo literal appears under `frontend/` |
+
+---
+
+### Task 1: Theme palette guard script
+
+**Files:**
+- Create: `frontend/scripts/verify-theme-palette.mjs`
+- Modify: `frontend/package.json` (add `"verify:theme": "node scripts/verify-theme-palette.mjs"`)
+
+- [ ] **Step 1: Add the script**
+
+Create `frontend/scripts/verify-theme-palette.mjs`:
+
+```javascript
+import fs from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const ROOT = path.join(__dirname, "..")
+const SKIP_DIR_NAMES = new Set([".next", "node_modules", ".git"])
+
+/** @param {string} dir */
+function* walkFiles(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true })
+  for (const e of entries) {
+    const full = path.join(dir, e.name)
+    if (e.isDirectory()) {
+      if (SKIP_DIR_NAMES.has(e.name)) continue
+      yield* walkFiles(full)
+    } else if (/\.(tsx|ts|jsx|js|css|mdx)$/i.test(e.name)) {
+      yield full
+    }
+  }
+}
+
+const NEEDLE = "99, 102, 241"
+const hits = []
+for (const file of walkFiles(ROOT)) {
+  const text = fs.readFileSync(file, "utf8")
+  if (text.includes(NEEDLE)) {
+    hits.push(path.relative(ROOT, file))
+  }
+}
+
+if (hits.length) {
+  console.error(`Forbidden indigo literal "${NEEDLE}" found in:\n${hits.join("\n")}`)
+  process.exit(1)
+}
+console.log("Theme palette guard: no forbidden indigo literal under frontend/.")
+process.exit(0)
+```
+
+- [ ] **Step 2: Wire npm script**
+
+In `frontend/package.json`, inside `"scripts"`, add:
+
+```json
+"verify:theme": "node scripts/verify-theme-palette.mjs"
+```
+
+- [ ] **Step 3: Run guard on current tree (baseline)**
+
+Run from repo root:
+
+```bash
+cd frontend
+npm run verify:theme
+```
+
+**Expected before theme work:** Exit code **1** and a list of files (many), proving the guard fires.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/scripts/verify-theme-palette.mjs frontend/package.json
+git commit -m "Add frontend theme palette guard script and npm script."
+```
+
+---
+
+### Task 2: `globals.css` — light tokens, dark tokens, glass, neon, scrollbar
+
+**Files:**
+- Modify: `frontend/app/globals.css` (replace `:root`, `.dark`, and utility blocks listed below)
+
+- [ ] **Step 1: Replace `:root` block** (lines ~6–41) with light theme B — use these exact values:
+
+```css
+:root {
+  --background: oklch(0.99 0.012 125);
+  --foreground: oklch(0.18 0.02 150);
+  --card: oklch(0.985 0.01 125);
+  --card-foreground: oklch(0.18 0.02 150);
+  --popover: oklch(0.985 0.01 125);
+  --popover-foreground: oklch(0.18 0.02 150);
+  --primary: oklch(0.52 0.14 158);
+  --primary-foreground: oklch(0.99 0.01 125);
+  --secondary: oklch(0.94 0.06 125);
+  --secondary-foreground: oklch(0.22 0.04 150);
+  --muted: oklch(0.94 0.02 125);
+  --muted-foreground: oklch(0.45 0.03 150);
+  --accent: oklch(0.92 0.08 125);
+  --accent-foreground: oklch(0.2 0.04 150);
+  --destructive: oklch(0.55 0.2 25);
+  --destructive-foreground: oklch(0.99 0 0);
+  --border: oklch(0.88 0.03 130);
+  --input: oklch(0.9 0.025 130);
+  --ring: oklch(0.52 0.14 158);
+  --chart-1: oklch(0.52 0.14 158);
+  --chart-2: oklch(0.65 0.16 125);
+  --chart-3: oklch(0.72 0.14 115);
+  --chart-4: oklch(0.48 0.12 170);
+  --chart-5: oklch(0.58 0.1 145);
+  --radius: 0.5rem;
+  --sidebar: oklch(0.97 0.015 125);
+  --sidebar-foreground: oklch(0.18 0.02 150);
+  --sidebar-primary: oklch(0.52 0.14 158);
+  --sidebar-primary-foreground: oklch(0.99 0.01 125);
+  --sidebar-accent: oklch(0.92 0.08 125);
+  --sidebar-accent-foreground: oklch(0.2 0.04 150);
+  --sidebar-border: oklch(0.88 0.03 130);
+  --sidebar-ring: oklch(0.52 0.14 158);
+}
+```
+
+- [ ] **Step 2: Replace `.dark` block** (lines ~43–77) with achromatic dark:
+
+```css
+.dark {
+  --background: oklch(0.06 0 0);
+  --foreground: oklch(0.96 0 0);
+  --card: oklch(0.1 0 0);
+  --card-foreground: oklch(0.96 0 0);
+  --popover: oklch(0.1 0 0);
+  --popover-foreground: oklch(0.96 0 0);
+  --primary: oklch(0.93 0 0);
+  --primary-foreground: oklch(0.08 0 0);
+  --secondary: oklch(0.14 0 0);
+  --secondary-foreground: oklch(0.94 0 0);
+  --muted: oklch(0.12 0 0);
+  --muted-foreground: oklch(0.72 0 0);
+  --accent: oklch(0.16 0 0);
+  --accent-foreground: oklch(0.96 0 0);
+  --destructive: oklch(0.55 0.2 25);
+  --destructive-foreground: oklch(0.99 0 0);
+  --border: oklch(0.22 0 0);
+  --input: oklch(0.18 0 0);
+  --ring: oklch(0.88 0 0);
+  --chart-1: oklch(0.75 0 0);
+  --chart-2: oklch(0.65 0 0);
+  --chart-3: oklch(0.55 0 0);
+  --chart-4: oklch(0.85 0 0);
+  --chart-5: oklch(0.45 0 0);
+  --sidebar: oklch(0.08 0 0);
+  --sidebar-foreground: oklch(0.96 0 0);
+  --sidebar-primary: oklch(0.93 0 0);
+  --sidebar-primary-foreground: oklch(0.08 0 0);
+  --sidebar-accent: oklch(0.14 0 0);
+  --sidebar-accent-foreground: oklch(0.96 0 0);
+  --sidebar-border: oklch(0.2 0 0);
+  --sidebar-ring: oklch(0.88 0 0);
+}
+```
+
+- [ ] **Step 3: Update glass and neon utilities** — replace indigo `rgba(99, 102, 241, …)` with neutral glass (example; tune alphas if contrast checks fail):
+
+```css
+.glass-enhanced {
+  background: rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(25px) saturate(180%);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.neon-glow {
+  box-shadow: 0 0 5px rgba(255, 255, 255, 0.25), 0 0 10px rgba(255, 255, 255, 0.15),
+    0 0 15px rgba(255, 255, 255, 0.1), 0 0 20px rgba(255, 255, 255, 0.06);
+}
+
+.neon-glow-enhanced {
+  box-shadow: 0 0 5px rgba(255, 255, 255, 0.2), 0 0 10px rgba(255, 255, 255, 0.12),
+    0 0 15px rgba(255, 255, 255, 0.08), 0 0 20px rgba(255, 255, 255, 0.05), 0 0 35px rgba(255, 255, 255, 0.03);
+  transition: box-shadow 0.3s ease;
+}
+
+.neon-glow-enhanced:hover {
+  box-shadow: 0 0 5px rgba(255, 255, 255, 0.35), 0 0 10px rgba(255, 255, 255, 0.22),
+    0 0 15px rgba(255, 255, 255, 0.14), 0 0 20px rgba(255, 255, 255, 0.1), 0 0 35px rgba(255, 255, 255, 0.06);
+}
+```
+
+Keep `.glass` / `.glass-card` structure; swap any slate/indigo tints to `rgba(255,255,255,…)` / `rgba(15,23,42,…)` as appropriate for light-on-dark glass.
+
+- [ ] **Step 4: Run lint**
+
+```bash
+cd frontend
+npm run lint
+```
+
+**Expected:** No new ESLint errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/app/globals.css
+git commit -m "Remap theme tokens and neutral glass utilities for dark and light modes."
+```
+
+---
+
+### Task 3: Floating navbar — idle chrome and brand, preserve orange follow
+
+**Files:**
+- Modify: `frontend/components/floating-navbar.tsx`
+
+- [ ] **Step 1: Idle border and `boxShadow`** on the main `motion.div` (inline `style` ~127–133 and mobile menu ~316–318): replace `rgba(99, 102, 241, …)` with neutral silver, e.g. `rgba(255, 255, 255, 0.14)` (dark) and `rgba(15, 23, 42, 0.12)` (light).
+
+- [ ] **Step 2: “Dynamic Orange Border Glow” layer** (~188–204): replace **non-hover** indigo `border` / `boxShadow` strings with the same neutral silver as Step 1; keep `isHovering` branches that switch to orange `rgba(255, 165, 0, …)` unchanged in behavior.
+
+- [ ] **Step 3: Logo circle and wordmark** (~210–214): replace `from-blue-500 to-violet-500` and `from-blue-400 to-violet-400` with `from-emerald-500 to-lime-400` (or `to-teal-400`) so brand matches palette B.
+
+- [ ] **Step 4: `navItems` accent dots** (~73–103): replace `text-purple-400`, `text-blue-400`, `text-indigo-400` with condition-appropriate hues (e.g. Parkinson’s `text-teal-400`, Diabetes `text-cyan-400`, Information `text-emerald-400`) — no purple/indigo.
+
+- [ ] **Step 5: Verify orange follow blocks untouched** — the two `motion.div` layers using `glowPosition` and `rgba(255, 165, 0` / `rgba(255, 140, 0` / `rgba(255, 69, 0` must remain byte-identical in color strings and `animate` props.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/components/floating-navbar.tsx
+git commit -m "Retheme navbar idle chrome and logo while preserving orange cursor glow."
+```
+
+---
+
+### Task 4: Home page — hero, pills, CTA, cursor-follow
+
+**Files:**
+- Modify: `frontend/app/page.tsx`
+
+- [ ] **Step 1:** Replace hero icon gradient, title gradient, neon shadow, and feature pills (`blue` / `indigo` / `violet`) with **emerald** / **lime** / **teal** equivalents per spec §3.
+
+- [ ] **Step 2:** “Start Prediction” button — `className` gradient: use `from-emerald-600 to-teal-600` (or `to-lime-600`); replace `style.boxShadow` blues with emerald/lime rgba, e.g. `0 0 25px rgba(16, 185, 129, 0.55), 0 0 50px rgba(132, 204, 22, 0.35)`.
+
+- [ ] **Step 3:** Cursor-follow `motion.div` `background` radial (~192): use `rgba(16, 185, 129, 0.85)` → `rgba(132, 204, 22, 0.5)` → `transparent` stops (match parent CTA).
+
+- [ ] **Step 4:** Trust row: change `bg-blue-500` / `text-blue-400` to **cyan or slate**; change `bg-purple-500` / `text-purple-400` to **lime or emerald** so no purple/blue-purple row.
+
+- [ ] **Step 5:** Footer / secondary blocks that still use `from-blue-500 to-violet-500` → emerald/lime.
+
+- [ ] **Step 6:** `npm run lint` then commit:
+
+```bash
+git add frontend/app/page.tsx
+git commit -m "Retheme home page hero, CTAs, and cursor-follow to emerald and lime."
+```
+
+---
+
+### Task 5: Prediction tabs — section chrome and card interactions
+
+**Files:**
+- Modify: `frontend/components/prediction-tabs.tsx`
+
+- [ ] **Step 1:** Replace pill `from-blue-500/10 to-violet-500/10` and heading `from-blue-400 via-indigo-400 to-violet-400` with emerald/lime gradients.
+
+- [ ] **Step 2:** Per-tab config: update `color` and `glowColor` Tailwind classes — Parkinson entry must not use `purple` / `indigo`; use `teal` / `emerald`.
+
+- [ ] **Step 3:** Inline `border` and `linear-gradient` using `rgba(99, 102, 241` — replace with `rgba(16, 185, 129, …)` or the active card’s accent rgba.
+
+- [ ] **Step 4:** `group-hover:from-blue-400 group-hover:to-violet-400` → emerald/lime; `animate-pulse` boxShadow rgba indigo → emerald.
+
+- [ ] **Step 5:** Lint and commit:
+
+```bash
+git add frontend/components/prediction-tabs.tsx
+git commit -m "Retheme prediction tabs headers and card hover glows away from indigo."
+```
+
+---
+
+### Task 6: Contact section
+
+**Files:**
+- Modify: `frontend/components/contact-section.tsx`
+
+- [ ] **Step 1:** Heading gradient, icon tile gradient, submit button, inline `border: "1px solid rgba(99, 102, 241`", decorative blurs — all emerald/lime/teal as appropriate; no `rgba(99, 102, 241`.
+
+- [ ] **Step 2:** Lint and commit:
+
+```bash
+git add frontend/components/contact-section.tsx
+git commit -m "Retheme contact section gradients and glass border to palette B."
+```
+
+---
+
+### Task 7: User menu and subscription modal
+
+**Files:**
+- Modify: `frontend/components/user-menu.tsx`
+- Modify: `frontend/components/subscription-modal.tsx`
+
+- [ ] **Step 1:** Replace `from-blue-500/20 to-purple-500/20` (and hover variants) with `from-emerald-500/20 to-lime-500/20` and matching borders.
+
+- [ ] **Step 2:** Lint and commit:
+
+```bash
+git add frontend/components/user-menu.tsx frontend/components/subscription-modal.tsx
+git commit -m "Retheme user menu and subscription modal accent strips."
+```
+
+---
+
+### Task 8: Auth guard
+
+**Files:**
+- Modify: `frontend/components/auth-guard.tsx`
+
+- [ ] **Step 1:** Replace `purple-400` / `purple-300` bullets and labels with `emerald-400` / `emerald-300` (or neutral `slate`).
+
+- [ ] **Step 2:** Commit:
+
+```bash
+git add frontend/components/auth-guard.tsx
+git commit -m "Replace purple accents in auth guard with emerald neutrals."
+```
+
+---
+
+### Task 9: Predict route pages (heart, diabetes, parkinsons, common-diseases)
+
+**Files:**
+- Modify: `frontend/app/predict/heart/page.tsx`
+- Modify: `frontend/app/predict/diabetes/page.tsx`
+- Modify: `frontend/app/predict/parkinsons/page.tsx`
+- Modify: `frontend/app/predict/common-diseases/page.tsx`
+
+- [ ] **Step 1 (heart):** Keep red/pink/rose hero story; replace logo `blue-violet` with **red–rose** or **emerald** for app mark only if you need a non-purple lockup; replace `bg-gradient-to-r from-blue-500 to-violet-500` icon with `from-rose-500 to-red-600`. Remove background blur blobs that are only `pink` if spec prefers red/neutral — keep soft `pink/rose` acceptable for heart; do **not** add purple.
+
+- [ ] **Step 2 (diabetes):** Teal/cyan gradients and borders (`border-cyan-500/20`); remove `blue`/`violet` icon and titles.
+
+- [ ] **Step 3 (parkinsons):** Deep teal/forest blobs and gradients; `border-teal-500/20` or `border-emerald-900/30`; remove all `purple`/`indigo`/`violet`.
+
+- [ ] **Step 4 (common diseases):** Ensure greens align with `emerald` / `lime` family.
+
+- [ ] **Step 5:** Lint and commit:
+
+```bash
+git add frontend/app/predict/heart/page.tsx frontend/app/predict/diabetes/page.tsx frontend/app/predict/parkinsons/page.tsx frontend/app/predict/common-diseases/page.tsx
+git commit -m "Retheme predict landing pages per condition accent spec."
+```
+
+---
+
+### Task 10: Forms (heart, diabetes, parkinsons, common-diseases)
+
+**Files:**
+- Modify: `frontend/components/forms/heart-prediction-form.tsx`
+- Modify: `frontend/components/forms/diabetes-prediction-form.tsx`
+- Modify: `frontend/components/forms/parkinsons-prediction-form.tsx`
+- Modify: `frontend/components/forms/common-diseases-prediction-form.tsx`
+
+- [ ] **Step 1:** Heart — replace `text-purple-400`, `from-purple-500 to-pink-400` progress with `rose`/`red`/`neutral` only.
+
+- [ ] **Step 2:** Diabetes — purple/pink bars → `cyan`/`teal`.
+
+- [ ] **Step 3:** Parkinsons — all `purple`/`indigo`/`pink` tabs, buttons, rings → `teal`/`emerald`/`slate`.
+
+- [ ] **Step 4:** Common diseases — purple/pink → `emerald`/`green`.
+
+- [ ] **Step 5:** Lint and commit:
+
+```bash
+git add frontend/components/forms/heart-prediction-form.tsx frontend/components/forms/diabetes-prediction-form.tsx frontend/components/forms/parkinsons-prediction-form.tsx frontend/components/forms/common-diseases-prediction-form.tsx
+git commit -m "Align prediction form accents with non-purple condition palettes."
+```
+
+---
+
+### Task 11: Repo-wide sweep and verification
+
+**Files:**
+- Grep under `frontend/` (excluding `.next`) for: `purple-`, `violet-`, `indigo-`, `from-blue-5`, `to-violet`, `99, 102, 241`
+
+- [ ] **Step 1: Search**
+
+```bash
+cd frontend
+rg "99, 102, 241|from-blue-500 to-violet|via-indigo|purple-500|violet-500|indigo-500" --glob '!**/.next/**'
+```
+
+**Expected:** No matches in in-scope UI files. If matches remain in `components/ui/*` shadcn primitives, only change them if they hardcode marketing colors; otherwise leave defaults that use CSS variables (they follow `globals.css`).
+
+- [ ] **Step 2: Run guard**
+
+```bash
+npm run verify:theme
+```
+
+**Expected:** Exit code **0**.
+
+- [ ] **Step 3: Production build**
+
+```bash
+npm run build
+```
+
+**Expected:** Compiled successfully.
+
+- [ ] **Step 4: Manual smoke (human)** per spec §7: theme toggle, home, each predict page, contact, signed-in menu.
+
+- [ ] **Step 5:** Final commit if any sweep fixes:
+
+```bash
+git add -A
+git commit -m "Remove remaining indigo and purple chrome after theme sweep."
+```
+
+---
+
+## Plan self-review (spec coverage)
+
+| Spec section | Tasks covering it |
+|----------------|-------------------|
+| §1 Goals | Tasks 2–11 |
+| §2 Dark tokens + glass | Task 2 |
+| §3 Light palette B | Task 2 `:root` |
+| §4 Per-route accents | Tasks 5, 9, 10 |
+| §5 Interactive glow / navbar | Tasks 3, 4, 5 |
+| §6 File scope | File map + tasks 2–10 |
+| §7 A11y / QA | Task 2 values + Task 11 manual; adjust OKLCH if contrast fails |
+| §8 Anti-patterns | Task 1 + Task 11 guard |
+
+**Placeholder scan:** None.  
+**Type consistency:** N/A (no shared TS types). Orange follow “byte-identical” check in Task 3 is intentional for spec compliance.
+
+---
+
+**Plan complete and saved to `docs/superpowers/plans/2026-04-30-frontend-theme-redesign.md`. Two execution options:**
+
+**1. Subagent-Driven (recommended)** — Dispatch a fresh subagent per task, review between tasks, fast iteration.
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+**Which approach do you want?**

--- a/docs/superpowers/specs/2026-04-30-frontend-theme-design.md
+++ b/docs/superpowers/specs/2026-04-30-frontend-theme-design.md
@@ -1,0 +1,76 @@
+# Frontend theme redesign — design spec
+
+**Date:** 2026-04-30  
+**Status:** Approved for implementation planning (user sign-off on design sections + refinements below).
+
+## 1. Goals
+
+- **Dark mode:** Minimal chroma — effectively **black / charcoal / silver / white** only in design tokens and shared glass. Preserve **glassmorphism** on cards (blur, saturation, translucent fills, thin highlights).
+- **Light mode:** **Bright and colorful** using option **B** — near-white base with **lime or chartreuse** plus **emerald** accents. No purple, blue-purple, violet, or indigo-forward branding on themed surfaces.
+- **Avoid “AI default” palettes:** No site-wide indigo–violet–purple neon, no blue-purple gradient primaries, no `rgb(99, 102, 241)`-style accents in **global** utilities or marketing shells (see §6 for navbar specifics).
+
+## 2. Dark mode — tokens and glass
+
+- **CSS variables (`:root` / `.dark` in `frontend/app/globals.css`):** Remap `--background`, `--foreground`, `--primary`, `--ring`, `--border`, `--muted`, charts, and sidebar tokens to **achromatic OKLCH** (chroma at or near **0**, small lightness steps). No hue-based “primary” in dark except optional **white / silver** for focus and primary actions.
+- **Shared utilities:** Update `.glass`, `.glass-card`, `.glass-enhanced`, `.neon-glow`, `.neon-glow-enhanced`, and scrollbar thumb rules to use **white/silver/black alpha** borders and shadows — not indigo.
+- **Cards:** Keep structure: `backdrop-filter` blur + optional `saturate`, semi-transparent dark fill, **subtle** inner top highlight, soft outer shadow. Read as glass, not flat panels.
+
+## 3. Light mode — palette B (lime + emerald)
+
+- **Background / surfaces:** Very light neutrals with optional **hint of yellow-green** (low chroma) so the page feels fresh, not cold gray-purple.
+- **Primary / ring / interactive defaults:** **Emerald** family (OKLCH hue roughly **150–165°**).
+- **Secondary accent / gradients / pills:** **Chartreuse / lime** (hue roughly **115–130°**), used for badges, secondary buttons, and small highlights so the UI feels lively without purple.
+- **Charts (`--chart-1` …):** Analogous greens / yellow-greens; avoid purple and blue-violet endpoints.
+
+## 4. Per-route and per-condition accents
+
+| Area | Direction |
+|------|-----------|
+| **Heart** | Keep **red** as the clinical signal; replace **purple–pink** progress or icon accents that exist only as generic defaults with **red / rose / neutral** as appropriate. |
+| **Parkinson’s** | Replace **purple / indigo / violet** hero and shell styling with **deep teal or forest** (cool but not on purple axis). |
+| **Diabetes** | Replace **blue–violet** identity with **teal / cyan** distinct from global emerald primary. |
+| **Common diseases** | Keep **green** or nudge toward emerald so it does not fight the global primary. |
+| **Home, contact, prediction tabs, auth, forms, subscription modal** | Remove blue / indigo / violet / purple **chrome** in favor of palette B or condition-local accents as above. |
+
+## 5. Interactive glow and cursor-follow (user refinement)
+
+- **Navbar (`floating-navbar.tsx`):** **Keep** the existing **orange** cursor-follow radial layers and their **motion timing** (`opacity` / `scale` / `duration` / `ease`). **Keep** the behavior where hover intensifies warm border glow.
+- **Forbidden hues in pointer-linked effects:** Any **mouse-position-driven** glow, radial spotlight, or animated wash that currently uses **blue, pink, or purple** (including indigo/violet) must be **recolored to match the nearest parent UI** — e.g. primary CTA uses **emerald/lime** radials and shadows; neutral/ghost controls use **slate / white** radials only.
+- **Non-follow chrome:** Static borders and shadows on the nav pill that are purely **indigo** may be shifted to **neutral silver / warm-neutral** so dark mode stays minimal, as long as **orange follow** and **hover motion** behavior remain unchanged.
+
+**Known implementation today (audit):**
+
+- **Home CTA** (`page.tsx` — “Start Prediction”): cursor-follow radial and `boxShadow` use blue/indigo/violet — remap to **emerald/lime** to match the updated button surface.
+- **Prediction tab cards** (`prediction-tabs.tsx`): gradient wash and pulse use `rgba(99, 102, 241, …)` — remap to **active card / tab accent** (emerald–lime or condition color), not purple-blue.
+- **Navbar:** Orange follow **unchanged**; indigo in **idle** border/shadow/logo may be updated per §2 and §4 brand, without altering orange follow layers.
+
+## 6. Scope — files
+
+| In scope | Notes |
+|----------|--------|
+| `frontend/app/globals.css` | Tokens; glass; neon; scrollbar. |
+| `frontend/app/page.tsx` | Hero, pills, CTA gradients, cursor-follow, trust icons as needed. |
+| `frontend/components/prediction-tabs.tsx` | Headers, gradients, card hover, glow. |
+| `frontend/components/contact-section.tsx` | Headings, buttons, decorative blurs, inline borders. |
+| `frontend/components/floating-navbar.tsx` | Orange follow **preserved**; indigo/violet in logo/wordmark/idle chrome per §5. |
+| `frontend/components/user-menu.tsx`, `subscription-modal.tsx`, `auth-guard.tsx` | Replace purple/blue gradient chrome. |
+| `frontend/app/predict/*/page.tsx` | Hero blobs, titles, glass borders per §4. |
+| `frontend/components/forms/*.tsx` | Replace generic purple/pink/indigo accents with condition-appropriate or neutral colors. |
+
+**Out of scope for this spec:** Backend, API routes, analytics, new components, font family changes.
+
+## 7. Accessibility and QA
+
+- **Contrast:** WCAG **AA** minimum for text and interactive states on both themes.
+- **Focus:** `ring` color must remain obvious on dark (e.g. light ring) and on light (emerald).
+- **Manual smoke:** Toggle dark/light; home; one predict page per condition family; contact form; signed-in header if applicable.
+
+## 8. Anti-patterns (explicit)
+
+- Purple, violet, indigo, and blue-purple **gradients** as global marketing or primary CTA (except tiny unavoidable third-party assets — none planned).
+- **Cursor-follow** or **hover spotlight** using blue / pink / purple where a local accent exists — must match **parent** control colors per §5.
+- Reintroducing `rgb(99, 102, 241)` (or equivalent) in **global** glass/neon after this change.
+
+## 9. Implementation note
+
+After this document is accepted in the repo, the next step is a separate **implementation plan** (per project workflow: `writing-plans` skill), then coding and tests — not part of this design file.

--- a/frontend/app/auth/signin/page.tsx
+++ b/frontend/app/auth/signin/page.tsx
@@ -96,7 +96,7 @@ export default function SignInPage() {
         />
         
         {/* Animated Background Elements */}
-        <div className="absolute top-1/4 left-1/4 w-96 h-96 bg-blue-500/10 rounded-full blur-3xl animate-pulse" />
+        <div className="absolute top-1/4 left-1/4 w-96 h-96 bg-emerald-500/10 rounded-full blur-3xl animate-pulse" />
         <div className="absolute bottom-1/3 right-1/4 w-64 h-64 bg-slate-300/5 rounded-full blur-2xl animate-pulse delay-1000" />
         
         {/* Content */}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -4,76 +4,76 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
-  /* Light theme colors - bright and clean */
-  --background: oklch(0.98 0.01 240);
-  --foreground: oklch(0.1 0.05 240);
-  --card: oklch(0.95 0.02 240);
-  --card-foreground: oklch(0.1 0.05 240);
-  --popover: oklch(0.95 0.02 240);
-  --popover-foreground: oklch(0.1 0.05 240);
-  --primary: oklch(0.6 0.25 260);
-  --primary-foreground: oklch(1.0 0 0);
-  --secondary: oklch(0.92 0.05 240);
-  --secondary-foreground: oklch(0.2 0.08 240);
-  --muted: oklch(0.94 0.03 240);
-  --muted-foreground: oklch(0.4 0.05 240);
-  --accent: oklch(0.9 0.08 260);
-  --accent-foreground: oklch(0.1 0.05 240);
-  --destructive: oklch(0.6861 0.2061 14.9941);
-  --destructive-foreground: oklch(1.0 0 0);
-  --border: oklch(0.85 0.05 240);
-  --input: oklch(0.9 0.05 240);
-  --ring: oklch(0.6 0.25 260);
-  --chart-1: oklch(0.6 0.25 260);
-  --chart-2: oklch(0.65 0.2 280);
-  --chart-3: oklch(0.7 0.15 300);
-  --chart-4: oklch(0.55 0.3 240);
-  --chart-5: oklch(0.75 0.1 320);
+  /* Light theme: palette B - emerald primary with lime/chartreuse accents */
+  --background: oklch(0.99 0.012 125);
+  --foreground: oklch(0.18 0.02 150);
+  --card: oklch(0.985 0.01 125);
+  --card-foreground: oklch(0.18 0.02 150);
+  --popover: oklch(0.985 0.01 125);
+  --popover-foreground: oklch(0.18 0.02 150);
+  --primary: oklch(0.52 0.14 158);
+  --primary-foreground: oklch(0.99 0.01 125);
+  --secondary: oklch(0.94 0.06 125);
+  --secondary-foreground: oklch(0.22 0.04 150);
+  --muted: oklch(0.94 0.02 125);
+  --muted-foreground: oklch(0.45 0.03 150);
+  --accent: oklch(0.92 0.08 125);
+  --accent-foreground: oklch(0.2 0.04 150);
+  --destructive: oklch(0.55 0.2 25);
+  --destructive-foreground: oklch(0.99 0 0);
+  --border: oklch(0.88 0.03 130);
+  --input: oklch(0.9 0.025 130);
+  --ring: oklch(0.52 0.14 158);
+  --chart-1: oklch(0.52 0.14 158);
+  --chart-2: oklch(0.65 0.16 125);
+  --chart-3: oklch(0.72 0.14 115);
+  --chart-4: oklch(0.48 0.12 170);
+  --chart-5: oklch(0.58 0.1 145);
   --radius: 0.5rem;
-  --sidebar: oklch(0.94 0.03 240);
-  --sidebar-foreground: oklch(0.1 0.05 240);
-  --sidebar-primary: oklch(0.6 0.25 260);
-  --sidebar-primary-foreground: oklch(1.0 0 0);
-  --sidebar-accent: oklch(0.9 0.08 260);
-  --sidebar-accent-foreground: oklch(0.1 0.05 240);
-  --sidebar-border: oklch(0.85 0.05 240);
-  --sidebar-ring: oklch(0.6 0.25 260);
+  --sidebar: oklch(0.97 0.015 125);
+  --sidebar-foreground: oklch(0.18 0.02 150);
+  --sidebar-primary: oklch(0.52 0.14 158);
+  --sidebar-primary-foreground: oklch(0.99 0.01 125);
+  --sidebar-accent: oklch(0.92 0.08 125);
+  --sidebar-accent-foreground: oklch(0.2 0.04 150);
+  --sidebar-border: oklch(0.88 0.03 130);
+  --sidebar-ring: oklch(0.52 0.14 158);
 }
 
 .dark {
-  /* Updated to black background with blue/purple theme */
-  --background: oklch(0.02 0.01 240);
-  --foreground: oklch(0.95 0.05 240);
-  --card: oklch(0.05 0.02 240);
-  --card-foreground: oklch(0.95 0.05 240);
-  --popover: oklch(0.05 0.02 240);
-  --popover-foreground: oklch(0.95 0.05 240);
-  --primary: oklch(0.65 0.25 260);
-  --primary-foreground: oklch(0.02 0.01 240);
-  --secondary: oklch(0.1 0.05 240);
-  --secondary-foreground: oklch(0.9 0.08 240);
-  --muted: oklch(0.08 0.03 240);
-  --muted-foreground: oklch(0.7 0.05 240);
-  --accent: oklch(0.15 0.08 260);
-  --accent-foreground: oklch(0.95 0.05 240);
-  --destructive: oklch(0.6861 0.2061 14.9941);
-  --destructive-foreground: oklch(1.0 0 0);
-  --border: oklch(0.15 0.05 240);
-  --input: oklch(0.15 0.05 240);
-  --ring: oklch(0.65 0.25 260);
-  --chart-1: oklch(0.65 0.25 260);
-  --chart-2: oklch(0.7 0.2 280);
-  --chart-3: oklch(0.75 0.15 300);
-  --chart-4: oklch(0.6 0.3 240);
-  --chart-5: oklch(0.8 0.1 320);
-  --sidebar: oklch(0.05 0.02 240);
-  --sidebar-foreground: oklch(0.95 0.05 240);
-  --sidebar-primary: oklch(0.65 0.25 260);
-  --sidebar-primary-foreground: oklch(0.02 0.01 240);
-  --sidebar-accent: oklch(0.15 0.08 260);
-  --sidebar-accent-foreground: oklch(0.95 0.05 240);
-  --sidebar-border: oklch(0.15 0.05 240);
-  --sidebar-ring: oklch(0.65 0.25 260);
+  /* Dark theme: achromatic black/charcoal/silver glassmorphism */
+  --background: oklch(0.06 0 0);
+  --foreground: oklch(0.96 0 0);
+  --card: oklch(0.1 0 0);
+  --card-foreground: oklch(0.96 0 0);
+  --popover: oklch(0.1 0 0);
+  --popover-foreground: oklch(0.96 0 0);
+  --primary: oklch(0.93 0 0);
+  --primary-foreground: oklch(0.08 0 0);
+  --secondary: oklch(0.14 0 0);
+  --secondary-foreground: oklch(0.94 0 0);
+  --muted: oklch(0.12 0 0);
+  --muted-foreground: oklch(0.72 0 0);
+  --accent: oklch(0.16 0 0);
+  --accent-foreground: oklch(0.96 0 0);
+  --destructive: oklch(0.55 0.2 25);
+  --destructive-foreground: oklch(0.99 0 0);
+  --border: oklch(0.22 0 0);
+  --input: oklch(0.18 0 0);
+  --ring: oklch(0.88 0 0);
+  --chart-1: oklch(0.75 0 0);
+  --chart-2: oklch(0.65 0 0);
+  --chart-3: oklch(0.55 0 0);
+  --chart-4: oklch(0.85 0 0);
+  --chart-5: oklch(0.45 0 0);
+  --sidebar: oklch(0.08 0 0);
+  --sidebar-foreground: oklch(0.96 0 0);
+  --sidebar-primary: oklch(0.93 0 0);
+  --sidebar-primary-foreground: oklch(0.08 0 0);
+  --sidebar-accent: oklch(0.14 0 0);
+  --sidebar-accent-foreground: oklch(0.96 0 0);
+  --sidebar-border: oklch(0.2 0 0);
+  --sidebar-ring: oklch(0.88 0 0);
 }
 
 @theme inline {
@@ -200,37 +200,33 @@
   border: 1px solid rgba(148, 163, 184, 0.2);
 }
 
-/* Enhanced glassmorphism with better blur effects */
+/* Enhanced glassmorphism: neutral silver/white alpha for achromatic dark mode */
 .glass-enhanced {
-  /* Updated glassmorphism for black background with blue theme */
   background: rgba(0, 0, 0, 0.4);
   backdrop-filter: blur(25px) saturate(180%);
-  border: 1px solid rgba(99, 102, 241, 0.2);
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5), inset 0 1px 0 rgba(99, 102, 241, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5), inset 0 1px 0 rgba(255, 255, 255, 0.08);
 }
 
-/* Neon glow effects */
+/* Neutral silver neon glow - replaces former indigo glow */
 .neon-glow {
-  /* Updated neon glow for blue/purple theme */
-  box-shadow: 0 0 5px rgba(99, 102, 241, 0.5), 0 0 10px rgba(99, 102, 241, 0.4), 0 0 15px rgba(99, 102, 241, 0.3), 0 0
-    20px rgba(99, 102, 241, 0.2);
+  box-shadow: 0 0 5px rgba(255, 255, 255, 0.25), 0 0 10px rgba(255, 255, 255, 0.15), 0 0 15px rgba(255, 255, 255, 0.1),
+    0 0 20px rgba(255, 255, 255, 0.06);
 }
 
 .neon-text {
   text-shadow: 0 0 5px currentColor, 0 0 10px currentColor, 0 0 15px currentColor;
 }
 
-/* Improved neon effects with better performance */
 .neon-glow-enhanced {
-  /* Updated enhanced neon glow for blue/purple theme */
-  box-shadow: 0 0 5px rgba(99, 102, 241, 0.4), 0 0 10px rgba(99, 102, 241, 0.3), 0 0 15px rgba(99, 102, 241, 0.2), 0 0
-    20px rgba(99, 102, 241, 0.1), 0 0 35px rgba(99, 102, 241, 0.05);
+  box-shadow: 0 0 5px rgba(255, 255, 255, 0.2), 0 0 10px rgba(255, 255, 255, 0.12),
+    0 0 15px rgba(255, 255, 255, 0.08), 0 0 20px rgba(255, 255, 255, 0.05), 0 0 35px rgba(255, 255, 255, 0.03);
   transition: box-shadow 0.3s ease;
 }
 
 .neon-glow-enhanced:hover {
-  box-shadow: 0 0 5px rgba(99, 102, 241, 0.6), 0 0 10px rgba(99, 102, 241, 0.5), 0 0 15px rgba(99, 102, 241, 0.4), 0 0
-    20px rgba(99, 102, 241, 0.3), 0 0 35px rgba(99, 102, 241, 0.2);
+  box-shadow: 0 0 5px rgba(255, 255, 255, 0.35), 0 0 10px rgba(255, 255, 255, 0.22),
+    0 0 15px rgba(255, 255, 255, 0.14), 0 0 20px rgba(255, 255, 255, 0.1), 0 0 35px rgba(255, 255, 255, 0.06);
 }
 
 /* Smooth scroll behavior */

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -377,12 +377,12 @@ export default function HomePage() {
                     </a>
                   </li>
                   <li>
-                    <a href="#" className="hover:text-emerald-400 transition-colors duration-200 flex items-center space-x-2">
+                    <a href="/privacy" className="hover:text-emerald-400 transition-colors duration-200 flex items-center space-x-2">
                       <span>Privacy Policy</span>
                     </a>
                   </li>
                   <li>
-                    <a href="#" className="hover:text-emerald-400 transition-colors duration-200 flex items-center space-x-2">
+                    <a href="/terms" className="hover:text-emerald-400 transition-colors duration-200 flex items-center space-x-2">
                       <span>Terms of Service</span>
                     </a>
                   </li>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -96,12 +96,12 @@ export default function HomePage() {
               className="flex items-center justify-center mb-6"
             >
               <div className="relative">
-                <div className="w-16 h-16 bg-gradient-to-r from-blue-500 via-indigo-500 to-violet-500 rounded-2xl flex items-center justify-center shadow-2xl shadow-blue-500/25">
+                <div className="w-16 h-16 bg-gradient-to-r from-emerald-500 via-teal-500 to-lime-400 rounded-2xl flex items-center justify-center shadow-2xl shadow-emerald-500/25">
                   <svg className="w-10 h-10 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
                   </svg>
                 </div>
-                <div className="absolute -inset-2 bg-gradient-to-r from-blue-500 via-indigo-500 to-violet-500 rounded-2xl opacity-20 blur-lg animate-pulse"></div>
+                <div className="absolute -inset-2 bg-gradient-to-r from-emerald-500 via-teal-500 to-lime-400 rounded-2xl opacity-20 blur-lg animate-pulse"></div>
               </div>
             </motion.div>
 
@@ -110,7 +110,7 @@ export default function HomePage() {
               initial={{ opacity: 0, y: 30 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 1, delay: 0.4 }}
-              className="text-3xl md:text-5xl lg:text-6xl font-bold bg-gradient-to-r from-blue-400 via-indigo-400 to-violet-400 bg-clip-text text-transparent mb-4 neon-text"
+              className="text-3xl md:text-5xl lg:text-6xl font-bold bg-gradient-to-r from-emerald-400 via-teal-400 to-lime-300 bg-clip-text text-transparent mb-4 neon-text"
             >
               AI Health Predictor
             </motion.h1>
@@ -132,30 +132,30 @@ export default function HomePage() {
                   initial={{ opacity: 0, scale: 0.9 }}
                   animate={{ opacity: 1, scale: 1 }}
                   transition={{ duration: 0.6, delay: 0.8 }}
-                  className="flex items-center space-x-2 bg-blue-500/10 border border-blue-500/20 rounded-full px-4 py-2 backdrop-blur-sm"
+                  className="flex items-center space-x-2 bg-emerald-500/10 border border-emerald-500/20 rounded-full px-4 py-2 backdrop-blur-sm"
                 >
-                  <div className="w-2 h-2 bg-blue-400 rounded-full animate-pulse"></div>
-                  <span className="text-sm text-blue-300 font-medium">97% Accuracy</span>
+                  <div className="w-2 h-2 bg-emerald-400 rounded-full animate-pulse"></div>
+                  <span className="text-sm text-emerald-300 font-medium">97% Accuracy</span>
                 </motion.div>
                 
                 <motion.div
                   initial={{ opacity: 0, scale: 0.9 }}
                   animate={{ opacity: 1, scale: 1 }}
                   transition={{ duration: 0.6, delay: 0.9 }}
-                  className="flex items-center space-x-2 bg-indigo-500/10 border border-indigo-500/20 rounded-full px-4 py-2 backdrop-blur-sm"
+                  className="flex items-center space-x-2 bg-teal-500/10 border border-teal-500/20 rounded-full px-4 py-2 backdrop-blur-sm"
                 >
-                  <div className="w-2 h-2 bg-indigo-400 rounded-full animate-pulse"></div>
-                  <span className="text-sm text-indigo-300 font-medium">4 Conditions</span>
+                  <div className="w-2 h-2 bg-teal-400 rounded-full animate-pulse"></div>
+                  <span className="text-sm text-teal-300 font-medium">4 Conditions</span>
                 </motion.div>
                 
                 <motion.div
                   initial={{ opacity: 0, scale: 0.9 }}
                   animate={{ opacity: 1, scale: 1 }}
                   transition={{ duration: 0.6, delay: 1.0 }}
-                  className="flex items-center space-x-2 bg-violet-500/10 border border-violet-500/20 rounded-full px-4 py-2 backdrop-blur-sm"
+                  className="flex items-center space-x-2 bg-lime-500/10 border border-lime-500/20 rounded-full px-4 py-2 backdrop-blur-sm"
                 >
-                  <div className="w-2 h-2 bg-violet-400 rounded-full animate-pulse"></div>
-                  <span className="text-sm text-violet-300 font-medium">Instant Results</span>
+                  <div className="w-2 h-2 bg-lime-400 rounded-full animate-pulse"></div>
+                  <span className="text-sm text-lime-300 font-medium">Instant Results</span>
                 </motion.div>
               </div>
             </motion.div>
@@ -175,11 +175,11 @@ export default function HomePage() {
                 onMouseEnter={() => setStartBtnHovering(true)}
                 onMouseLeave={() => setStartBtnHovering(false)}
                 onMouseMove={handleStartBtnMouseMove}
-                className="relative px-8 py-4 text-white font-semibold rounded-2xl shadow-2xl transition-all duration-300 overflow-hidden border border-slate-600 bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-500 hover:to-indigo-500"
+                className="relative px-8 py-4 text-white font-semibold rounded-2xl shadow-2xl transition-all duration-300 overflow-hidden border border-emerald-700/40 bg-gradient-to-r from-emerald-600 to-teal-600 hover:from-emerald-500 hover:to-teal-500"
                 style={{
-                  boxShadow: startBtnHovering 
-                    ? "0 0 25px rgba(59, 130, 246, 0.6), 0 0 50px rgba(99, 102, 241, 0.4), 0 0 75px rgba(139, 92, 246, 0.2)"
-                    : "0 0 15px rgba(59, 130, 246, 0.3), 0 0 30px rgba(99, 102, 241, 0.2)"
+                  boxShadow: startBtnHovering
+                    ? "0 0 25px rgba(16, 185, 129, 0.55), 0 0 50px rgba(132, 204, 22, 0.35), 0 0 75px rgba(20, 184, 166, 0.2)"
+                    : "0 0 15px rgba(16, 185, 129, 0.3), 0 0 30px rgba(132, 204, 22, 0.18)"
                 }}
               >
                 <motion.div
@@ -189,7 +189,7 @@ export default function HomePage() {
                     top: startBtnGlow.y - 40,
                     width: "80px",
                     height: "80px",
-                    background: "radial-gradient(circle, rgba(59, 130, 246, 0.8) 0%, rgba(99, 102, 241, 0.6) 30%, rgba(139, 92, 246, 0.4) 60%, transparent 80%)",
+                    background: "radial-gradient(circle, rgba(16, 185, 129, 0.85) 0%, rgba(132, 204, 22, 0.5) 30%, rgba(20, 184, 166, 0.3) 60%, transparent 80%)",
                     borderRadius: "50%",
                     filter: "blur(15px)",
                   }}
@@ -245,16 +245,16 @@ export default function HomePage() {
                   <span className="text-xs text-slate-400">HIPAA Compliant</span>
                 </div>
                 <div className="flex items-center space-x-2">
-                  <div className="w-6 h-6 bg-blue-500/20 rounded-full flex items-center justify-center">
-                    <svg className="w-4 h-4 text-blue-400" fill="currentColor" viewBox="0 0 20 20">
+                  <div className="w-6 h-6 bg-cyan-500/20 rounded-full flex items-center justify-center">
+                    <svg className="w-4 h-4 text-cyan-400" fill="currentColor" viewBox="0 0 20 20">
                       <path fillRule="evenodd" d="M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z" clipRule="evenodd" />
                     </svg>
                   </div>
                   <span className="text-xs text-slate-400">Data Secure</span>
                 </div>
                 <div className="flex items-center space-x-2">
-                  <div className="w-6 h-6 bg-purple-500/20 rounded-full flex items-center justify-center">
-                    <svg className="w-4 h-4 text-purple-400" fill="currentColor" viewBox="0 0 20 20">
+                  <div className="w-6 h-6 bg-lime-500/20 rounded-full flex items-center justify-center">
+                    <svg className="w-4 h-4 text-lime-400" fill="currentColor" viewBox="0 0 20 20">
                       <path d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
                     </svg>
                   </div>
@@ -292,10 +292,10 @@ export default function HomePage() {
                 transition={{ duration: 0.6 }}
                 className="flex items-center justify-center space-x-3 mb-4"
               >
-                <div className="w-8 h-8 bg-gradient-to-r from-blue-500 to-violet-500 rounded-full flex items-center justify-center">
+                <div className="w-8 h-8 bg-gradient-to-r from-emerald-500 to-lime-400 rounded-full flex items-center justify-center">
                   <div className="w-4 h-4 border border-white rounded-full border-t-transparent" />
                 </div>
-                <span className="text-lg font-bold bg-gradient-to-r from-blue-400 to-violet-400 bg-clip-text text-transparent">
+                <span className="text-lg font-bold bg-gradient-to-r from-emerald-400 to-lime-300 bg-clip-text text-transparent">
                   AI Health Predictor
                 </span>
               </motion.div>
@@ -336,22 +336,22 @@ export default function HomePage() {
                 <h4 className="text-white font-semibold mb-4 text-lg">Predictions</h4>
                 <ul className="space-y-3 text-sm text-slate-400">
                   <li>
-                    <a href="#prediction" className="hover:text-blue-400 transition-colors duration-200 flex items-center space-x-2">
+                    <a href="#prediction" className="hover:text-emerald-400 transition-colors duration-200 flex items-center space-x-2">
                       <span>Heart Disease Analysis</span>
                     </a>
                   </li>
                   <li>
-                    <a href="#prediction" className="hover:text-blue-400 transition-colors duration-200 flex items-center space-x-2">
+                    <a href="#prediction" className="hover:text-emerald-400 transition-colors duration-200 flex items-center space-x-2">
                       <span>Diabetes Prediction</span>
                     </a>
                   </li>
                   <li>
-                    <a href="#prediction" className="hover:text-blue-400 transition-colors duration-200 flex items-center space-x-2">
+                    <a href="#prediction" className="hover:text-emerald-400 transition-colors duration-200 flex items-center space-x-2">
                       <span>Parkinson's Assessment</span>
                     </a>
                   </li>
                   <li>
-                    <a href="#prediction" className="hover:text-blue-400 transition-colors duration-200 flex items-center space-x-2">
+                    <a href="#prediction" className="hover:text-emerald-400 transition-colors duration-200 flex items-center space-x-2">
                       <span>Common Diseases</span>
                     </a>
                   </li>
@@ -365,24 +365,24 @@ export default function HomePage() {
                     <a
                       href="https://health-predictor-wiki.vercel.app/"
                       target="_blank"
-                      className="hover:text-blue-400 transition-colors duration-200 flex items-center space-x-2"
+                      className="hover:text-emerald-400 transition-colors duration-200 flex items-center space-x-2"
                       rel="noreferrer"
                     >
                       <span>Documentation</span>
                     </a>
                   </li>
                   <li>
-                    <a href="#contact" className="hover:text-blue-400 transition-colors duration-200 flex items-center space-x-2">
+                    <a href="#contact" className="hover:text-emerald-400 transition-colors duration-200 flex items-center space-x-2">
                       <span>Contact Support</span>
                     </a>
                   </li>
                   <li>
-                    <a href="#" className="hover:text-blue-400 transition-colors duration-200 flex items-center space-x-2">
+                    <a href="#" className="hover:text-emerald-400 transition-colors duration-200 flex items-center space-x-2">
                       <span>Privacy Policy</span>
                     </a>
                   </li>
                   <li>
-                    <a href="#" className="hover:text-blue-400 transition-colors duration-200 flex items-center space-x-2">
+                    <a href="#" className="hover:text-emerald-400 transition-colors duration-200 flex items-center space-x-2">
                       <span>Terms of Service</span>
                     </a>
                   </li>
@@ -413,7 +413,7 @@ export default function HomePage() {
                     </p>
                   </div>
                   <div className="pt-2">
-                    <span className="inline-flex items-center px-2 py-1 rounded-full text-xs bg-blue-500/10 text-blue-400 border border-blue-500/20">
+                    <span className="inline-flex items-center px-2 py-1 rounded-full text-xs bg-emerald-500/10 text-emerald-400 border border-emerald-500/20">
                       AI-Powered Technology
                     </span>
                   </div>

--- a/frontend/app/predict/common-diseases/page.tsx
+++ b/frontend/app/predict/common-diseases/page.tsx
@@ -40,10 +40,10 @@ export default function CommonDiseasesPredictionPage() {
             </Link>
 
             <div className="flex items-center space-x-3">
-              <div className="w-10 h-10 bg-gradient-to-r from-blue-500 to-violet-500 rounded-full flex items-center justify-center">
+              <div className="w-10 h-10 bg-gradient-to-r from-emerald-500 to-lime-400 rounded-full flex items-center justify-center">
                 <Stethoscope className="w-5 h-5 text-white" />
               </div>
-              <span className="text-xl font-bold bg-gradient-to-r from-blue-400 to-violet-400 bg-clip-text text-transparent">
+              <span className="text-xl font-bold bg-gradient-to-r from-emerald-400 to-lime-300 bg-clip-text text-transparent">
                 Health Predictor
               </span>
             </div>

--- a/frontend/app/predict/diabetes/page.tsx
+++ b/frontend/app/predict/diabetes/page.tsx
@@ -15,9 +15,9 @@ export default function DiabetesPredictionPage() {
       <div className="min-h-screen bg-black relative overflow-hidden">
         {/* Background elements */}
         <div className="fixed inset-0 opacity-20 pointer-events-none">
-          <div className="absolute top-1/4 left-1/4 w-96 h-96 bg-blue-600/30 rounded-full blur-3xl" />
+          <div className="absolute top-1/4 left-1/4 w-96 h-96 bg-teal-600/30 rounded-full blur-3xl" />
           <div className="absolute top-3/4 right-1/4 w-80 h-80 bg-cyan-600/30 rounded-full blur-3xl" />
-          <div className="absolute bottom-1/4 left-1/2 w-72 h-72 bg-sky-600/30 rounded-full blur-3xl" />
+          <div className="absolute bottom-1/4 left-1/2 w-72 h-72 bg-emerald-700/30 rounded-full blur-3xl" />
         </div>
 
         {/* Header */}
@@ -40,10 +40,10 @@ export default function DiabetesPredictionPage() {
             </Link>
 
             <div className="flex items-center space-x-3">
-              <div className="w-10 h-10 bg-gradient-to-r from-blue-500 to-violet-500 rounded-full flex items-center justify-center">
+              <div className="w-10 h-10 bg-gradient-to-r from-emerald-500 to-lime-400 rounded-full flex items-center justify-center">
                 <Droplet className="w-5 h-5 text-white" />
               </div>
-              <span className="text-xl font-bold bg-gradient-to-r from-blue-400 to-violet-400 bg-clip-text text-transparent">
+              <span className="text-xl font-bold bg-gradient-to-r from-emerald-400 to-lime-300 bg-clip-text text-transparent">
                 Health Predictor
               </span>
             </div>
@@ -64,7 +64,7 @@ export default function DiabetesPredictionPage() {
                 initial={{ scale: 0.8, opacity: 0 }}
                 animate={{ scale: 1, opacity: 1 }}
                 transition={{ duration: 0.6, delay: 0.3 }}
-                className="inline-flex items-center justify-center p-6 rounded-3xl bg-gradient-to-r from-blue-500 to-cyan-500 shadow-2xl mb-8"
+                className="inline-flex items-center justify-center p-6 rounded-3xl bg-gradient-to-r from-cyan-500 to-teal-500 shadow-2xl mb-8"
               >
                 <Droplet className="w-16 h-16 text-white" />
               </motion.div>
@@ -72,7 +72,7 @@ export default function DiabetesPredictionPage() {
                 initial={{ y: 20, opacity: 0 }}
                 animate={{ y: 0, opacity: 1 }}
                 transition={{ duration: 0.8, delay: 0.4 }}
-                className="text-5xl md:text-6xl lg:text-7xl font-bold bg-gradient-to-r from-blue-400 via-cyan-400 to-sky-400 bg-clip-text text-transparent mb-6 text-balance leading-tight"
+                className="text-5xl md:text-6xl lg:text-7xl font-bold bg-gradient-to-r from-cyan-400 via-teal-400 to-emerald-400 bg-clip-text text-transparent mb-6 text-balance leading-tight"
               >
                 Diabetes Prediction
               </motion.h1>
@@ -92,11 +92,11 @@ export default function DiabetesPredictionPage() {
               initial={{ scale: 0.95, opacity: 0 }}
               animate={{ scale: 1, opacity: 1 }}
               transition={{ duration: 0.8, delay: 0.6 }}
-              className="glass-enhanced rounded-3xl p-8 md:p-12 lg:p-16 shadow-2xl border border-blue-500/20"
+              className="glass-enhanced rounded-3xl p-8 md:p-12 lg:p-16 shadow-2xl border border-cyan-500/20"
               style={{
                 background: "linear-gradient(135deg, rgba(0, 0, 0, 0.6) 0%, rgba(15, 15, 15, 0.8) 100%)",
                 backdropFilter: "blur(20px)",
-                boxShadow: "0 25px 50px -12px rgba(59, 130, 246, 0.25), 0 0 0 1px rgba(59, 130, 246, 0.1)",
+                boxShadow: "0 25px 50px -12px rgba(6, 182, 212, 0.25), 0 0 0 1px rgba(6, 182, 212, 0.1)",
               }}
             >
               <DiabetesPredictionForm />

--- a/frontend/app/predict/heart/page.tsx
+++ b/frontend/app/predict/heart/page.tsx
@@ -40,10 +40,10 @@ export default function HeartPredictionPage() {
             </Link>
 
             <div className="flex items-center space-x-3">
-              <div className="w-10 h-10 bg-gradient-to-r from-blue-500 to-violet-500 rounded-full flex items-center justify-center">
+              <div className="w-10 h-10 bg-gradient-to-r from-emerald-500 to-lime-400 rounded-full flex items-center justify-center">
                 <Heart className="w-5 h-5 text-white" />
               </div>
-              <span className="text-xl font-bold bg-gradient-to-r from-blue-400 to-violet-400 bg-clip-text text-transparent">
+              <span className="text-xl font-bold bg-gradient-to-r from-emerald-400 to-lime-300 bg-clip-text text-transparent">
                 Health Predictor
               </span>
             </div>

--- a/frontend/app/predict/parkinsons/page.tsx
+++ b/frontend/app/predict/parkinsons/page.tsx
@@ -15,9 +15,9 @@ export default function ParkinsonsPredictionPage() {
       <div className="min-h-screen bg-black relative overflow-hidden">
         {/* Background elements */}
         <div className="fixed inset-0 opacity-20 pointer-events-none">
-          <div className="absolute top-1/4 left-1/4 w-96 h-96 bg-purple-600/30 rounded-full blur-3xl" />
-          <div className="absolute top-3/4 right-1/4 w-80 h-80 bg-indigo-600/30 rounded-full blur-3xl" />
-          <div className="absolute bottom-1/4 left-1/2 w-72 h-72 bg-violet-600/30 rounded-full blur-3xl" />
+          <div className="absolute top-1/4 left-1/4 w-96 h-96 bg-teal-700/30 rounded-full blur-3xl" />
+          <div className="absolute top-3/4 right-1/4 w-80 h-80 bg-emerald-800/30 rounded-full blur-3xl" />
+          <div className="absolute bottom-1/4 left-1/2 w-72 h-72 bg-teal-600/30 rounded-full blur-3xl" />
         </div>
 
         {/* Header */}
@@ -40,10 +40,10 @@ export default function ParkinsonsPredictionPage() {
             </Link>
 
             <div className="flex items-center space-x-3">
-              <div className="w-10 h-10 bg-gradient-to-r from-blue-500 to-violet-500 rounded-full flex items-center justify-center">
+              <div className="w-10 h-10 bg-gradient-to-r from-emerald-500 to-lime-400 rounded-full flex items-center justify-center">
                 <Brain className="w-5 h-5 text-white" />
               </div>
-              <span className="text-xl font-bold bg-gradient-to-r from-blue-400 to-violet-400 bg-clip-text text-transparent">
+              <span className="text-xl font-bold bg-gradient-to-r from-emerald-400 to-lime-300 bg-clip-text text-transparent">
                 Health Predictor
               </span>
             </div>
@@ -64,7 +64,7 @@ export default function ParkinsonsPredictionPage() {
                 initial={{ scale: 0.8, opacity: 0 }}
                 animate={{ scale: 1, opacity: 1 }}
                 transition={{ duration: 0.6, delay: 0.3 }}
-                className="inline-flex items-center justify-center p-6 rounded-3xl bg-gradient-to-r from-purple-500 to-indigo-500 shadow-2xl mb-8"
+                className="inline-flex items-center justify-center p-6 rounded-3xl bg-gradient-to-r from-teal-600 to-emerald-700 shadow-2xl mb-8"
               >
                 <Brain className="w-16 h-16 text-white" />
               </motion.div>
@@ -72,7 +72,7 @@ export default function ParkinsonsPredictionPage() {
                 initial={{ y: 20, opacity: 0 }}
                 animate={{ y: 0, opacity: 1 }}
                 transition={{ duration: 0.8, delay: 0.4 }}
-                className="text-5xl md:text-6xl lg:text-7xl font-bold bg-gradient-to-r from-purple-400 via-indigo-400 to-violet-400 bg-clip-text text-transparent mb-6 text-balance leading-tight"
+                className="text-5xl md:text-6xl lg:text-7xl font-bold bg-gradient-to-r from-teal-400 via-emerald-400 to-teal-300 bg-clip-text text-transparent mb-6 text-balance leading-tight"
               >
                 Parkinson's Disease Prediction
               </motion.h1>
@@ -92,11 +92,11 @@ export default function ParkinsonsPredictionPage() {
               initial={{ scale: 0.95, opacity: 0 }}
               animate={{ scale: 1, opacity: 1 }}
               transition={{ duration: 0.8, delay: 0.6 }}
-              className="glass-enhanced rounded-3xl p-8 md:p-12 lg:p-16 shadow-2xl border border-purple-500/20"
+              className="glass-enhanced rounded-3xl p-8 md:p-12 lg:p-16 shadow-2xl border border-teal-500/20"
               style={{
                 background: "linear-gradient(135deg, rgba(0, 0, 0, 0.6) 0%, rgba(15, 15, 15, 0.8) 100%)",
                 backdropFilter: "blur(20px)",
-                boxShadow: "0 25px 50px -12px rgba(147, 51, 234, 0.25), 0 0 0 1px rgba(147, 51, 234, 0.1)",
+                boxShadow: "0 25px 50px -12px rgba(20, 184, 166, 0.25), 0 0 0 1px rgba(20, 184, 166, 0.1)",
               }}
             >
               <ParkinsonsPredictionForm />

--- a/frontend/components/auth-guard.tsx
+++ b/frontend/components/auth-guard.tsx
@@ -18,7 +18,7 @@ export function AuthGuard({ children, requiredForTabs = [] }: AuthGuardProps) {
   if (status === "loading") {
     return (
       <div className="flex items-center justify-center min-h-[400px]">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-emerald-500"></div>
       </div>
     )
   }
@@ -67,16 +67,16 @@ export function AuthGuard({ children, requiredForTabs = [] }: AuthGuardProps) {
                   </div>
                 </li>
                 <li className="flex items-start space-x-3">
-                  <div className="w-2 h-2 bg-blue-400 rounded-full mt-2 flex-shrink-0"></div>
+                  <div className="w-2 h-2 bg-teal-400 rounded-full mt-2 flex-shrink-0"></div>
                   <div>
-                    <span className="font-medium text-blue-300">Medicine Suggestions</span>
+                    <span className="font-medium text-teal-300">Medicine Suggestions</span>
                     <p className="text-white/50 mt-1">Access curated pharmaceutical recommendations for your condition</p>
                   </div>
                 </li>
                 <li className="flex items-start space-x-3">
-                  <div className="w-2 h-2 bg-purple-400 rounded-full mt-2 flex-shrink-0"></div>
+                  <div className="w-2 h-2 bg-lime-400 rounded-full mt-2 flex-shrink-0"></div>
                   <div>
-                    <span className="font-medium text-purple-300">Prediction History</span>
+                    <span className="font-medium text-lime-300">Prediction History</span>
                     <p className="text-white/50 mt-1">Track your health assessments over time</p>
                   </div>
                 </li>

--- a/frontend/components/contact-section.tsx
+++ b/frontend/components/contact-section.tsx
@@ -81,7 +81,7 @@ export function ContactSection() {
         transition={{ duration: 0.8, ease: "easeOut" }}
         className="text-center mb-8"
       >
-        <h2 className="text-3xl md:text-4xl font-bold bg-gradient-to-r from-blue-400 via-indigo-400 to-violet-400 bg-clip-text text-transparent mb-3 text-balance">
+        <h2 className="text-3xl md:text-4xl font-bold bg-gradient-to-r from-emerald-400 via-teal-400 to-lime-300 bg-clip-text text-transparent mb-3 text-balance">
           Get In Touch
         </h2>
         <p className="text-base text-slate-400 max-w-xl mx-auto text-pretty">
@@ -101,7 +101,7 @@ export function ContactSection() {
           style={{
             background: "rgba(0, 0, 0, 0.4)",
             backdropFilter: "blur(20px)",
-            border: "1px solid rgba(99, 102, 241, 0.2)",
+            border: "1px solid rgba(16, 185, 129, 0.2)",
           }}
         >
           {/* Collapsible Header */}
@@ -112,7 +112,7 @@ export function ContactSection() {
             className="w-full p-6 md:p-8 flex items-center justify-between text-left focus:outline-none"
           >
             <div className="flex items-center space-x-3">
-              <div className="p-3 rounded-2xl bg-gradient-to-r from-blue-500 to-violet-500 shadow-lg">
+              <div className="p-3 rounded-2xl bg-gradient-to-r from-emerald-500 to-teal-500 shadow-lg">
                 <Mail className="w-6 h-6 text-white" />
               </div>
               <div>
@@ -157,7 +157,7 @@ export function ContactSection() {
                           id="name"
                           value={formData.name}
                           onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-                          className="w-full pl-10 pr-4 py-3 bg-slate-800/50 border border-slate-700 rounded-xl text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500/50 focus:border-blue-500/50 transition-all duration-200"
+                          className="w-full pl-10 pr-4 py-3 bg-slate-800/50 border border-slate-700 rounded-xl text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/50 focus:border-emerald-500/50 transition-all duration-200"
                           placeholder="Enter your full name"
                           required
                         />
@@ -180,7 +180,7 @@ export function ContactSection() {
                           id="email"
                           value={formData.email}
                           onChange={(e) => setFormData({ ...formData, email: e.target.value })}
-                          className="w-full pl-10 pr-4 py-3 bg-slate-800/50 border border-slate-700 rounded-xl text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500/50 focus:border-blue-500/50 transition-all duration-200"
+                          className="w-full pl-10 pr-4 py-3 bg-slate-800/50 border border-slate-700 rounded-xl text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/50 focus:border-emerald-500/50 transition-all duration-200"
                           placeholder="Enter your email address"
                           required
                         />
@@ -203,7 +203,7 @@ export function ContactSection() {
                           rows={4}
                           value={formData.message}
                           onChange={(e) => setFormData({ ...formData, message: e.target.value })}
-                          className="w-full pl-10 pr-4 py-3 bg-slate-800/50 border border-slate-700 rounded-xl text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500/50 focus:border-blue-500/50 transition-all duration-200 resize-none"
+                          className="w-full pl-10 pr-4 py-3 bg-slate-800/50 border border-slate-700 rounded-xl text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/50 focus:border-emerald-500/50 transition-all duration-200 resize-none"
                           placeholder="Tell us how we can help you..."
                           required
                         />
@@ -218,7 +218,7 @@ export function ContactSection() {
                       initial={{ opacity: 0, y: 20 }}
                       animate={{ opacity: 1, y: 0 }}
                       transition={{ duration: 0.5, delay: 0.4 }}
-                      className="w-full py-3 bg-gradient-to-r from-blue-500 to-violet-500 text-white font-semibold rounded-xl disabled:opacity-50 disabled:cursor-not-allowed hover:shadow-lg transition-all duration-200 flex items-center justify-center space-x-2"
+                      className="w-full py-3 bg-gradient-to-r from-emerald-500 to-teal-500 text-white font-semibold rounded-xl disabled:opacity-50 disabled:cursor-not-allowed hover:shadow-lg transition-all duration-200 flex items-center justify-center space-x-2"
                     >
                       {isSubmitting ? (
                         <>
@@ -239,8 +239,8 @@ export function ContactSection() {
           </AnimatePresence>
         </div>
 
-        <div className="absolute -top-4 -right-4 w-20 h-20 bg-gradient-to-r from-blue-500/20 to-violet-500/20 rounded-full blur-xl" />
-        <div className="absolute -bottom-4 -left-4 w-24 h-24 bg-gradient-to-r from-indigo-500/20 to-purple-500/20 rounded-full blur-xl" />
+        <div className="absolute -top-4 -right-4 w-20 h-20 bg-gradient-to-r from-emerald-500/20 to-lime-500/20 rounded-full blur-xl" />
+        <div className="absolute -bottom-4 -left-4 w-24 h-24 bg-gradient-to-r from-teal-500/20 to-emerald-500/20 rounded-full blur-xl" />
       </motion.div>
     </div>
   )

--- a/frontend/components/floating-navbar.tsx
+++ b/frontend/components/floating-navbar.tsx
@@ -79,12 +79,12 @@ export function FloatingNavbar() {
     {
       label: "Parkinson's",
       action: () => scrollToSection("prediction"),
-      color: "text-purple-400",
+      color: "text-teal-400",
     },
     {
       label: "Diabetes",
       action: () => scrollToSection("prediction"),
-      color: "text-blue-400",
+      color: "text-cyan-400",
     },
     {
       label: "Common Diseases",
@@ -99,7 +99,7 @@ export function FloatingNavbar() {
     {
       label: "Information",
       action: () => window.open("https://health-predictor-wiki.vercel.app/", "_blank"),
-      color: "text-indigo-400",
+      color: "text-emerald-400",
     },
   ]
 
@@ -126,10 +126,10 @@ export function FloatingNavbar() {
             style={{
               background: theme === "dark" ? "rgba(0, 0, 0, 0.7)" : "rgba(255, 255, 255, 0.7)",
               backdropFilter: "blur(25px)",
-              border: theme === "dark" ? "1px solid rgba(99, 102, 241, 0.3)" : "1px solid rgba(99, 102, 241, 0.2)",
-              boxShadow: theme === "dark" 
-                ? "0 0 30px rgba(99, 102, 241, 0.2), inset 0 0 30px rgba(99, 102, 241, 0.1)" 
-                : "0 0 30px rgba(99, 102, 241, 0.15), inset 0 0 30px rgba(99, 102, 241, 0.05)",
+              border: theme === "dark" ? "1px solid rgba(255, 255, 255, 0.14)" : "1px solid rgba(15, 23, 42, 0.12)",
+              boxShadow: theme === "dark"
+                ? "0 0 30px rgba(255, 255, 255, 0.08), inset 0 0 30px rgba(255, 255, 255, 0.05)"
+                : "0 0 30px rgba(15, 23, 42, 0.08), inset 0 0 30px rgba(15, 23, 42, 0.03)",
               width: "fit-content",
               maxWidth: "1000px",
             }}
@@ -189,17 +189,17 @@ export function FloatingNavbar() {
               className="absolute inset-0 rounded-full pointer-events-none"
               style={{
                 background: "transparent",
-                border: "1px solid rgba(99, 102, 241, 0.5)",
-                boxShadow: "0 0 20px rgba(99, 102, 241, 0.3), inset 0 0 20px rgba(99, 102, 241, 0.1)",
+                border: "1px solid rgba(255, 255, 255, 0.18)",
+                boxShadow: "0 0 20px rgba(255, 255, 255, 0.1), inset 0 0 20px rgba(255, 255, 255, 0.05)",
               }}
               animate={{
                 opacity: isHovering ? 1 : 0.6,
                 boxShadow: isHovering 
                   ? `0 0 40px rgba(255, 165, 0, 0.6), inset 0 0 40px rgba(255, 140, 0, 0.4), 0 0 60px rgba(255, 69, 0, 0.3)`
-                  : "0 0 20px rgba(99, 102, 241, 0.3), inset 0 0 20px rgba(99, 102, 241, 0.1)",
+                  : "0 0 20px rgba(255, 255, 255, 0.1), inset 0 0 20px rgba(255, 255, 255, 0.05)",
                 border: isHovering 
                   ? "1px solid rgba(255, 165, 0, 0.7)"
-                  : "1px solid rgba(99, 102, 241, 0.5)",
+                  : "1px solid rgba(255, 255, 255, 0.18)",
               }}
               transition={{ duration: 0.5 }}
             />
@@ -207,10 +207,10 @@ export function FloatingNavbar() {
             <div className="flex items-center justify-between w-full">
               {/* Logo */}
               <motion.div whileHover={{ scale: 1.05 }} className="flex items-center space-x-2">
-                <div className="w-6 h-6 md:w-8 md:h-8 bg-gradient-to-r from-blue-500 to-violet-500 rounded-full flex items-center justify-center">
+                <div className="w-6 h-6 md:w-8 md:h-8 bg-gradient-to-r from-emerald-500 to-lime-400 rounded-full flex items-center justify-center">
                   <Heart className="w-3 h-3 md:w-4 md:h-4 text-white" />
                 </div>
-                <span className={`font-bold text-sm md:text-lg bg-gradient-to-r from-blue-400 to-violet-400 bg-clip-text text-transparent`}>
+                <span className={`font-bold text-sm md:text-lg bg-gradient-to-r from-emerald-400 to-lime-300 bg-clip-text text-transparent`}>
                   Health Predictor
                 </span>
               </motion.div>
@@ -315,7 +315,7 @@ export function FloatingNavbar() {
                   style={{
                     background: theme === "dark" ? "rgba(0, 0, 0, 0.7)" : "rgba(255, 255, 255, 0.7)",
                     backdropFilter: "blur(25px)",
-                    border: theme === "dark" ? "1px solid rgba(99, 102, 241, 0.3)" : "1px solid rgba(99, 102, 241, 0.2)",
+                    border: theme === "dark" ? "1px solid rgba(255, 255, 255, 0.14)" : "1px solid rgba(15, 23, 42, 0.12)",
                   }}
                 >
                   <div className="space-y-2">

--- a/frontend/components/forms/common-diseases-prediction-form.tsx
+++ b/frontend/components/forms/common-diseases-prediction-form.tsx
@@ -193,7 +193,7 @@ export function ImprovedCommonDiseasesPredictionForm() {
       switch (risk) {
         case "low": return "from-green-500 to-emerald-400"
         case "medium": return "from-yellow-500 to-orange-400"
-        case "high": return "from-red-500 to-pink-400"
+        case "high": return "from-red-500 to-rose-400"
         default: return "from-slate-500 to-slate-400"
       }
     }
@@ -256,7 +256,7 @@ export function ImprovedCommonDiseasesPredictionForm() {
               {/* Risk Score */}
               <div className="bg-slate-800/50 rounded-xl p-6">
                 <div className="flex items-center mb-4">
-                  <TrendingUp className="w-5 h-5 text-purple-400 mr-2" />
+                  <TrendingUp className="w-5 h-5 text-emerald-400 mr-2" />
                   <h4 className="font-semibold text-white">Severity Score</h4>
                 </div>
                 <div className="w-full bg-slate-700 rounded-full h-3 mb-2">
@@ -264,7 +264,7 @@ export function ImprovedCommonDiseasesPredictionForm() {
                     initial={{ width: 0 }}
                     animate={{ width: `${result.riskScore}%` }}
                     transition={{ duration: 1, delay: 0.7 }}
-                    className="h-3 rounded-full bg-gradient-to-r from-purple-500 to-pink-400"
+                    className="h-3 rounded-full bg-gradient-to-r from-emerald-500 to-lime-400"
                   />
                 </div>
                 <p className="text-white font-semibold">{Math.round(result.riskScore)}%</p>
@@ -290,7 +290,7 @@ export function ImprovedCommonDiseasesPredictionForm() {
                       <h5 className="text-white font-medium mb-2">{subPred.condition}</h5>
                       <div className="w-full bg-slate-600 rounded-full h-2 mb-2">
                         <div
-                          className="h-2 rounded-full bg-gradient-to-r from-cyan-500 to-blue-400"
+                          className="h-2 rounded-full bg-gradient-to-r from-cyan-500 to-teal-400"
                           style={{ width: `${subPred.confidence}%` }}
                         />
                       </div>
@@ -323,8 +323,8 @@ export function ImprovedCommonDiseasesPredictionForm() {
                     </motion.li>
                   ))}
                 </ul>
-                <div className="mt-6 p-4 bg-blue-500/10 border border-blue-500/30 rounded-lg">
-                  <p className="text-blue-400 text-sm">
+                <div className="mt-6 p-4 bg-emerald-500/10 border border-emerald-500/30 rounded-lg">
+                  <p className="text-emerald-300 text-sm">
                     <strong>Note:</strong> {result.risk === "high"
                       ? "Please consult with a healthcare professional as soon as possible."
                       : result.risk === "medium"
@@ -340,7 +340,7 @@ export function ImprovedCommonDiseasesPredictionForm() {
             <AuthGuard requiredForTabs={["medicine"]}>
               <div className="bg-slate-800/30 rounded-xl p-6">
                 <h4 className="font-semibold text-white mb-4 flex items-center">
-                  <Pill className="w-5 h-5 text-blue-400 mr-2" />
+                  <Pill className="w-5 h-5 text-emerald-400 mr-2" />
                   Medicine Suggestions and Recommendations
                 </h4>
                 <div className="bg-orange-500/10 border border-orange-500/30 rounded-xl p-6">
@@ -359,8 +359,8 @@ export function ImprovedCommonDiseasesPredictionForm() {
                       <li>Over-the-counter alternatives and natural remedies</li>
                       <li>Emergency medication protocols when applicable</li>
                     </ul>
-                    <div className="bg-blue-500/10 border border-blue-500/30 rounded-lg p-4 mt-4">
-                      <p className="text-blue-400 text-sm font-semibold">
+                    <div className="bg-emerald-500/10 border border-emerald-500/30 rounded-lg p-4 mt-4">
+                      <p className="text-emerald-300 text-sm font-semibold">
                         📋 This feature will be implemented in future updates to provide comprehensive pharmaceutical guidance.
                       </p>
                     </div>

--- a/frontend/components/forms/diabetes-prediction-form.tsx
+++ b/frontend/components/forms/diabetes-prediction-form.tsx
@@ -264,13 +264,13 @@ export function DiabetesPredictionForm() {
       <motion.div initial={{ opacity: 0, scale: 0.9 }} animate={{ opacity: 1, scale: 1 }} className="py-8">
         <Tabs defaultValue="prediction" className="w-full">
           <TabsList className="grid w-full grid-cols-3 bg-slate-800/50">
-            <TabsTrigger value="prediction" className="data-[state=active]:bg-blue-500/20">
+            <TabsTrigger value="prediction" className="data-[state=active]:bg-cyan-500/20">
               Prediction
             </TabsTrigger>
-            <TabsTrigger value="recommendations" className="data-[state=active]:bg-blue-500/20">
+            <TabsTrigger value="recommendations" className="data-[state=active]:bg-cyan-500/20">
               Recommendations
             </TabsTrigger>
-            <TabsTrigger value="disclaimer" className="data-[state=active]:bg-blue-500/20">
+            <TabsTrigger value="disclaimer" className="data-[state=active]:bg-cyan-500/20">
               Important Notice
             </TabsTrigger>
           </TabsList>
@@ -300,7 +300,7 @@ export function DiabetesPredictionForm() {
               {/* Confidence Level */}
               <div className="bg-slate-800/50 rounded-xl p-6">
                 <div className="flex items-center mb-4">
-                  <Activity className="w-5 h-5 text-blue-400 mr-2" />
+                  <Activity className="w-5 h-5 text-cyan-400 mr-2" />
                   <h4 className="font-semibold text-white">Confidence Level</h4>
                 </div>
                 <div className="w-full bg-slate-700 rounded-full h-3 mb-2">
@@ -311,7 +311,7 @@ export function DiabetesPredictionForm() {
                     className={`h-3 rounded-full ${
                       result.risk === "low"
                         ? "bg-gradient-to-r from-green-500 to-emerald-400"
-                        : "bg-gradient-to-r from-blue-500 to-cyan-400"
+                        : "bg-gradient-to-r from-cyan-500 to-teal-400"
                     }`}
                   />
                 </div>
@@ -321,7 +321,7 @@ export function DiabetesPredictionForm() {
               {/* Risk Score */}
               <div className="bg-slate-800/50 rounded-xl p-6">
                 <div className="flex items-center mb-4">
-                  <TrendingUp className="w-5 h-5 text-purple-400 mr-2" />
+                  <TrendingUp className="w-5 h-5 text-teal-400 mr-2" />
                   <h4 className="font-semibold text-white">Risk Score</h4>
                 </div>
                 <div className="w-full bg-slate-700 rounded-full h-3 mb-2">
@@ -329,7 +329,7 @@ export function DiabetesPredictionForm() {
                     initial={{ width: 0 }}
                     animate={{ width: `${result.riskScore}%` }}
                     transition={{ duration: 1, delay: 0.7 }}
-                    className="h-3 rounded-full bg-gradient-to-r from-purple-500 to-pink-400"
+                    className="h-3 rounded-full bg-gradient-to-r from-cyan-500 to-teal-400"
                   />
                 </div>
                 <p className="text-white font-semibold">{Math.round(result.riskScore)}%</p>
@@ -355,7 +355,7 @@ export function DiabetesPredictionForm() {
                       <h5 className="text-white font-medium mb-2">{subPred.condition}</h5>
                       <div className="w-full bg-slate-600 rounded-full h-2 mb-2">
                         <div
-                          className="h-2 rounded-full bg-gradient-to-r from-cyan-500 to-blue-400"
+                          className="h-2 rounded-full bg-gradient-to-r from-cyan-500 to-teal-400"
                           style={{ width: `${subPred.confidence}%` }}
                         />
                       </div>
@@ -371,7 +371,7 @@ export function DiabetesPredictionForm() {
             <AuthGuard requiredForTabs={["recommendations"]}>
               <div className="bg-slate-800/30 rounded-xl p-6">
                 <h4 className="font-semibold text-white mb-4 flex items-center">
-                  <Droplet className="w-5 h-5 text-blue-400 mr-2" />
+                  <Droplet className="w-5 h-5 text-cyan-400 mr-2" />
                   Diabetes Prevention Recommendations
                 </h4>
                 <ul className="space-y-3">
@@ -383,7 +383,7 @@ export function DiabetesPredictionForm() {
                       transition={{ delay: index * 0.1 }}
                       className="flex items-start text-slate-300"
                     >
-                      <div className="w-2 h-2 bg-blue-400 rounded-full mt-2 mr-3 flex-shrink-0" />
+                      <div className="w-2 h-2 bg-cyan-400 rounded-full mt-2 mr-3 flex-shrink-0" />
                       <span className="text-sm leading-relaxed">{rec}</span>
                     </motion.li>
                   ))}
@@ -481,7 +481,7 @@ export function DiabetesPredictionForm() {
                 age: "",
               })
             }}
-            className="px-8 py-3 bg-gradient-to-r from-blue-500 to-cyan-500 text-white font-semibold rounded-xl hover:shadow-lg transition-all duration-200"
+            className="px-8 py-3 bg-gradient-to-r from-cyan-500 to-teal-500 text-white font-semibold rounded-xl hover:shadow-lg transition-all duration-200"
           >
             Take Another Test
           </motion.button>
@@ -500,7 +500,7 @@ export function DiabetesPredictionForm() {
             onClick={() => setMode("patient")}
             className={`px-6 py-3 rounded-lg font-semibold transition-all duration-200 flex items-center space-x-2 ${
               mode === "patient" 
-                ? "bg-blue-500/20 text-blue-400 shadow-lg" 
+                ? "bg-cyan-500/20 text-cyan-300 shadow-lg" 
                 : "text-slate-400 hover:text-white"
             }`}
           >
@@ -512,7 +512,7 @@ export function DiabetesPredictionForm() {
             onClick={() => setMode("doctor")}
             className={`px-6 py-3 rounded-lg font-semibold transition-all duration-200 flex items-center space-x-2 ${
               mode === "doctor" 
-                ? "bg-blue-500/20 text-blue-400 shadow-lg" 
+                ? "bg-cyan-500/20 text-cyan-300 shadow-lg" 
                 : "text-slate-400 hover:text-white"
             }`}
           >
@@ -552,7 +552,7 @@ export function DiabetesPredictionForm() {
                     whileTap={{ scale: 0.98 }}
                     className={`flex items-center p-4 rounded-xl cursor-pointer transition-all duration-200 ${
                       patientFormData[q.key] === option.value
-                        ? "bg-blue-500/20 border-blue-500/50 text-white"
+                        ? "bg-cyan-500/20 border-cyan-500/50 text-white"
                         : "bg-slate-800/50 border-slate-700 text-slate-300 hover:bg-slate-700/50"
                     } border`}
                   >
@@ -566,7 +566,7 @@ export function DiabetesPredictionForm() {
                     />
                     <div
                       className={`w-4 h-4 rounded-full border-2 mr-3 flex items-center justify-center ${
-                        patientFormData[q.key] === option.value ? "border-blue-500 bg-blue-500" : "border-slate-500"
+                        patientFormData[q.key] === option.value ? "border-cyan-500 bg-cyan-500" : "border-slate-500"
                       }`}
                     >
                       {patientFormData[q.key] === option.value && <div className="w-2 h-2 bg-white rounded-full" />}
@@ -583,7 +583,7 @@ export function DiabetesPredictionForm() {
             disabled={isLoading || Object.values(patientFormData).some((value) => !value)}
             whileHover={{ scale: 1.02 }}
             whileTap={{ scale: 0.98 }}
-            className="w-full py-4 bg-gradient-to-r from-blue-500 to-cyan-500 text-white font-semibold rounded-xl disabled:opacity-50 disabled:cursor-not-allowed hover:shadow-lg transition-all duration-200 flex items-center justify-center space-x-2"
+            className="w-full py-4 bg-gradient-to-r from-cyan-500 to-teal-500 text-white font-semibold rounded-xl disabled:opacity-50 disabled:cursor-not-allowed hover:shadow-lg transition-all duration-200 flex items-center justify-center space-x-2"
           >
             {isLoading ? (
               <>
@@ -619,7 +619,7 @@ export function DiabetesPredictionForm() {
                   step={q.step}
                   value={doctorFormData[q.key]}
                   onChange={(e) => setDoctorFormData({ ...doctorFormData, [q.key]: e.target.value })}
-                  className="w-full p-4 bg-slate-800/50 border border-slate-700 rounded-xl text-white placeholder-slate-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 transition-all duration-200"
+                  className="w-full p-4 bg-slate-800/50 border border-slate-700 rounded-xl text-white placeholder-slate-400 focus:border-cyan-500 focus:outline-none focus:ring-2 focus:ring-cyan-500/20 transition-all duration-200"
                   required
                 />
               </div>
@@ -631,7 +631,7 @@ export function DiabetesPredictionForm() {
             disabled={isLoading || Object.values(doctorFormData).some((value) => !value)}
             whileHover={{ scale: 1.02 }}
             whileTap={{ scale: 0.98 }}
-            className="w-full py-4 bg-gradient-to-r from-blue-500 to-cyan-500 text-white font-semibold rounded-xl disabled:opacity-50 disabled:cursor-not-allowed hover:shadow-lg transition-all duration-200 flex items-center justify-center space-x-2"
+            className="w-full py-4 bg-gradient-to-r from-cyan-500 to-teal-500 text-white font-semibold rounded-xl disabled:opacity-50 disabled:cursor-not-allowed hover:shadow-lg transition-all duration-200 flex items-center justify-center space-x-2"
           >
             {isLoading ? (
               <>

--- a/frontend/components/forms/heart-prediction-form.tsx
+++ b/frontend/components/forms/heart-prediction-form.tsx
@@ -323,7 +323,7 @@ export function HeartPredictionForm() {
               {/* Confidence Level */}
               <div className="bg-slate-800/50 rounded-xl p-6">
                 <div className="flex items-center mb-4">
-                  <Activity className="w-5 h-5 text-blue-400 mr-2" />
+                  <Activity className="w-5 h-5 text-rose-400 mr-2" />
                   <h4 className="font-semibold text-white">Confidence Level</h4>
                 </div>
                 <div className="w-full bg-slate-700 rounded-full h-3 mb-2">
@@ -344,7 +344,7 @@ export function HeartPredictionForm() {
               {/* Risk Score */}
               <div className="bg-slate-800/50 rounded-xl p-6">
                 <div className="flex items-center mb-4">
-                  <TrendingUp className="w-5 h-5 text-purple-400 mr-2" />
+                  <TrendingUp className="w-5 h-5 text-rose-400 mr-2" />
                   <h4 className="font-semibold text-white">Risk Score</h4>
                 </div>
                 <div className="w-full bg-slate-700 rounded-full h-3 mb-2">
@@ -352,7 +352,7 @@ export function HeartPredictionForm() {
                     initial={{ width: 0 }}
                     animate={{ width: `${result.riskScore}%` }}
                     transition={{ duration: 1, delay: 0.7 }}
-                    className="h-3 rounded-full bg-gradient-to-r from-purple-500 to-pink-400"
+                    className="h-3 rounded-full bg-gradient-to-r from-rose-500 to-red-500"
                   />
                 </div>
                 <p className="text-white font-semibold">{Math.round(result.riskScore)}%</p>
@@ -378,7 +378,7 @@ export function HeartPredictionForm() {
                       <h5 className="text-white font-medium mb-2">{subPred.condition}</h5>
                       <div className="w-full bg-slate-600 rounded-full h-2 mb-2">
                         <div
-                          className="h-2 rounded-full bg-gradient-to-r from-cyan-500 to-blue-400"
+                          className="h-2 rounded-full bg-gradient-to-r from-cyan-500 to-teal-400"
                           style={{ width: `${subPred.confidence}%` }}
                         />
                       </div>
@@ -416,10 +416,10 @@ export function HeartPredictionForm() {
               </div>
               
               {/* Medicine Suggestions Section - Only for authenticated users */}
-              <div className="bg-blue-500/10 border border-blue-500/30 rounded-xl p-6">
+              <div className="bg-slate-500/10 border border-slate-500/30 rounded-xl p-6">
                 <div className="flex items-center mb-4">
-                  <Stethoscope className="w-5 h-5 text-blue-400 mr-2" />
-                  <h4 className="font-semibold text-blue-300 text-lg">
+                  <Stethoscope className="w-5 h-5 text-slate-300 mr-2" />
+                  <h4 className="font-semibold text-slate-200 text-lg">
                     Medicine Suggestions
                   </h4>
                 </div>
@@ -428,15 +428,15 @@ export function HeartPredictionForm() {
                     <h5 className="font-medium text-white mb-2">Preventive Medications</h5>
                     <ul className="space-y-2 text-sm text-slate-300">
                       <li className="flex items-center">
-                        <div className="w-2 h-2 bg-blue-400 rounded-full mr-3" />
+                        <div className="w-2 h-2 bg-slate-400 rounded-full mr-3" />
                         Low-dose Aspirin (75-100mg daily) - Consult cardiologist
                       </li>
                       <li className="flex items-center">
-                        <div className="w-2 h-2 bg-blue-400 rounded-full mr-3" />
+                        <div className="w-2 h-2 bg-slate-400 rounded-full mr-3" />
                         ACE Inhibitors for blood pressure management
                       </li>
                       <li className="flex items-center">
-                        <div className="w-2 h-2 bg-blue-400 rounded-full mr-3" />
+                        <div className="w-2 h-2 bg-slate-400 rounded-full mr-3" />
                         Statins for cholesterol control (if indicated)
                       </li>
                     </ul>

--- a/frontend/components/forms/parkinsons-prediction-form.tsx
+++ b/frontend/components/forms/parkinsons-prediction-form.tsx
@@ -362,13 +362,13 @@ export function ParkinsonsPredictionForm() {
       <motion.div initial={{ opacity: 0, scale: 0.9 }} animate={{ opacity: 1, scale: 1 }} className="py-8">
         <Tabs defaultValue="prediction" className="w-full">
           <TabsList className="grid w-full grid-cols-3 bg-slate-800/50">
-            <TabsTrigger value="prediction" className="data-[state=active]:bg-purple-500/20">
+            <TabsTrigger value="prediction" className="data-[state=active]:bg-teal-500/20">
               Prediction
             </TabsTrigger>
-            <TabsTrigger value="recommendations" className="data-[state=active]:bg-purple-500/20">
+            <TabsTrigger value="recommendations" className="data-[state=active]:bg-teal-500/20">
               Recommendations
             </TabsTrigger>
-            <TabsTrigger value="disclaimer" className="data-[state=active]:bg-purple-500/20">
+            <TabsTrigger value="disclaimer" className="data-[state=active]:bg-teal-500/20">
               Important Notice
             </TabsTrigger>
           </TabsList>
@@ -398,7 +398,7 @@ export function ParkinsonsPredictionForm() {
               {/* Confidence Level */}
               <div className="bg-slate-800/50 rounded-xl p-6">
                 <div className="flex items-center mb-4">
-                  <Activity className="w-5 h-5 text-purple-400 mr-2" />
+                  <Activity className="w-5 h-5 text-teal-400 mr-2" />
                   <h4 className="font-semibold text-white">Confidence Level</h4>
                 </div>
                 <div className="w-full bg-slate-700 rounded-full h-3 mb-2">
@@ -409,7 +409,7 @@ export function ParkinsonsPredictionForm() {
                     className={`h-3 rounded-full ${
                       result.risk === "low"
                         ? "bg-gradient-to-r from-green-500 to-emerald-400"
-                        : "bg-gradient-to-r from-purple-500 to-indigo-400"
+                        : "bg-gradient-to-r from-teal-500 to-emerald-500"
                     }`}
                   />
                 </div>
@@ -419,7 +419,7 @@ export function ParkinsonsPredictionForm() {
               {/* Risk Score */}
               <div className="bg-slate-800/50 rounded-xl p-6">
                 <div className="flex items-center mb-4">
-                  <TrendingUp className="w-5 h-5 text-pink-400 mr-2" />
+                  <TrendingUp className="w-5 h-5 text-emerald-400 mr-2" />
                   <h4 className="font-semibold text-white">Risk Score</h4>
                 </div>
                 <div className="w-full bg-slate-700 rounded-full h-3 mb-2">
@@ -427,7 +427,7 @@ export function ParkinsonsPredictionForm() {
                     initial={{ width: 0 }}
                     animate={{ width: `${result.riskScore}%` }}
                     transition={{ duration: 1, delay: 0.7 }}
-                    className="h-3 rounded-full bg-gradient-to-r from-pink-500 to-purple-400"
+                    className="h-3 rounded-full bg-gradient-to-r from-emerald-500 to-teal-400"
                   />
                 </div>
                 <p className="text-white font-semibold">{Math.round(result.riskScore)}%</p>
@@ -453,11 +453,11 @@ export function ParkinsonsPredictionForm() {
                       <h5 className="text-white font-medium mb-2">{subPred.condition}</h5>
                       <div className="w-full bg-slate-600 rounded-full h-2 mb-2">
                         <div
-                          className="h-2 rounded-full bg-gradient-to-r from-purple-500 to-pink-400"
+                          className="h-2 rounded-full bg-gradient-to-r from-teal-500 to-emerald-400"
                           style={{ width: `${subPred.confidence}%` }}
                         />
                       </div>
-                      <p className="text-purple-400 text-sm font-semibold">{subPred.confidence}%</p>
+                      <p className="text-teal-400 text-sm font-semibold">{subPred.confidence}%</p>
                     </motion.div>
                   ))}
                 </div>
@@ -469,7 +469,7 @@ export function ParkinsonsPredictionForm() {
             <AuthGuard requiredForTabs={["recommendations"]}>
               <div className="bg-slate-800/30 rounded-xl p-6">
                 <h4 className="font-semibold text-white mb-4 flex items-center">
-                  <Brain className="w-5 h-5 text-purple-400 mr-2" />
+                  <Brain className="w-5 h-5 text-teal-400 mr-2" />
                   Neurological Care Recommendations
                 </h4>
                 <ul className="space-y-3">
@@ -481,7 +481,7 @@ export function ParkinsonsPredictionForm() {
                       transition={{ delay: index * 0.1 }}
                       className="flex items-start text-slate-300"
                     >
-                      <div className="w-2 h-2 bg-purple-400 rounded-full mt-2 mr-3 flex-shrink-0" />
+                      <div className="w-2 h-2 bg-teal-400 rounded-full mt-2 mr-3 flex-shrink-0" />
                       <span className="text-sm leading-relaxed">{rec}</span>
                     </motion.li>
                   ))}
@@ -489,10 +489,10 @@ export function ParkinsonsPredictionForm() {
               </div>
               
               {/* Medicine Suggestions Section - Only for authenticated users */}
-              <div className="bg-purple-500/10 border border-purple-500/30 rounded-xl p-6">
+              <div className="bg-teal-500/10 border border-teal-500/30 rounded-xl p-6">
                 <div className="flex items-center mb-4">
-                  <Stethoscope className="w-5 h-5 text-purple-400 mr-2" />
-                  <h4 className="font-semibold text-purple-300 text-lg">
+                  <Stethoscope className="w-5 h-5 text-teal-400 mr-2" />
+                  <h4 className="font-semibold text-teal-300 text-lg">
                     Medicine & Treatment Suggestions
                   </h4>
                 </div>
@@ -501,19 +501,19 @@ export function ParkinsonsPredictionForm() {
                     <h5 className="font-medium text-white mb-2">Parkinson's Management</h5>
                     <ul className="space-y-2 text-sm text-slate-300">
                       <li className="flex items-center">
-                        <div className="w-2 h-2 bg-purple-400 rounded-full mr-3" />
+                        <div className="w-2 h-2 bg-teal-400 rounded-full mr-3" />
                         Levodopa/Carbidopa - Gold standard for motor symptoms
                       </li>
                       <li className="flex items-center">
-                        <div className="w-2 h-2 bg-purple-400 rounded-full mr-3" />
+                        <div className="w-2 h-2 bg-teal-400 rounded-full mr-3" />
                         Dopamine Agonists (Pramipexole, Ropinirole)
                       </li>
                       <li className="flex items-center">
-                        <div className="w-2 h-2 bg-purple-400 rounded-full mr-3" />
+                        <div className="w-2 h-2 bg-teal-400 rounded-full mr-3" />
                         MAO-B Inhibitors (Selegiline, Rasagiline)
                       </li>
                       <li className="flex items-center">
-                        <div className="w-2 h-2 bg-purple-400 rounded-full mr-3" />
+                        <div className="w-2 h-2 bg-teal-400 rounded-full mr-3" />
                         Coenzyme Q10 (300-1200mg) - Neuroprotective support
                       </li>
                     </ul>
@@ -593,7 +593,7 @@ export function ParkinsonsPredictionForm() {
                 ppe: "",
               })
             }}
-            className="px-8 py-3 bg-gradient-to-r from-purple-500 to-indigo-500 text-white font-semibold rounded-xl hover:shadow-lg transition-all duration-200"
+            className="px-8 py-3 bg-gradient-to-r from-teal-500 to-emerald-600 text-white font-semibold rounded-xl hover:shadow-lg transition-all duration-200"
           >
             Take Another Test
           </motion.button>
@@ -612,7 +612,7 @@ export function ParkinsonsPredictionForm() {
             onClick={() => setMode("patient")}
             className={`px-6 py-3 rounded-lg font-semibold transition-all duration-200 flex items-center space-x-2 ${
               mode === "patient" 
-                ? "bg-purple-500/20 text-purple-400 shadow-lg" 
+                ? "bg-teal-500/20 text-teal-300 shadow-lg" 
                 : "text-slate-400 hover:text-white"
             }`}
           >
@@ -624,7 +624,7 @@ export function ParkinsonsPredictionForm() {
             onClick={() => setMode("doctor")}
             className={`px-6 py-3 rounded-lg font-semibold transition-all duration-200 flex items-center space-x-2 ${
               mode === "doctor" 
-                ? "bg-purple-500/20 text-purple-400 shadow-lg" 
+                ? "bg-teal-500/20 text-teal-300 shadow-lg" 
                 : "text-slate-400 hover:text-white"
             }`}
           >
@@ -664,7 +664,7 @@ export function ParkinsonsPredictionForm() {
                     whileTap={{ scale: 0.98 }}
                     className={`flex items-center p-4 rounded-xl cursor-pointer transition-all duration-200 ${
                       patientFormData[q.key] === option.value
-                        ? "bg-purple-500/20 border-purple-500/50 text-white"
+                        ? "bg-teal-500/20 border-teal-500/50 text-white"
                         : "bg-slate-800/50 border-slate-700 text-slate-300 hover:bg-slate-700/50"
                     } border`}
                   >
@@ -678,7 +678,7 @@ export function ParkinsonsPredictionForm() {
                     />
                     <div
                       className={`w-4 h-4 rounded-full border-2 mr-3 flex items-center justify-center ${
-                        patientFormData[q.key] === option.value ? "border-purple-500 bg-purple-500" : "border-slate-500"
+                        patientFormData[q.key] === option.value ? "border-teal-500 bg-teal-500" : "border-slate-500"
                       }`}
                     >
                       {patientFormData[q.key] === option.value && <div className="w-2 h-2 bg-white rounded-full" />}
@@ -695,7 +695,7 @@ export function ParkinsonsPredictionForm() {
             disabled={isLoading || Object.values(patientFormData).some((value) => !value)}
             whileHover={{ scale: 1.02 }}
             whileTap={{ scale: 0.98 }}
-            className="w-full py-4 bg-gradient-to-r from-purple-500 to-indigo-500 text-white font-semibold rounded-xl disabled:opacity-50 disabled:cursor-not-allowed hover:shadow-lg transition-all duration-200 flex items-center justify-center space-x-2"
+            className="w-full py-4 bg-gradient-to-r from-teal-500 to-emerald-600 text-white font-semibold rounded-xl disabled:opacity-50 disabled:cursor-not-allowed hover:shadow-lg transition-all duration-200 flex items-center justify-center space-x-2"
           >
             {isLoading ? (
               <>
@@ -731,7 +731,7 @@ export function ParkinsonsPredictionForm() {
                   step={q.step}
                   value={doctorFormData[q.key]}
                   onChange={(e) => setDoctorFormData({ ...doctorFormData, [q.key]: e.target.value })}
-                  className="w-full p-4 bg-slate-800/50 border border-slate-700 rounded-xl text-white placeholder-slate-400 focus:border-purple-500 focus:outline-none focus:ring-2 focus:ring-purple-500/20 transition-all duration-200"
+                  className="w-full p-4 bg-slate-800/50 border border-slate-700 rounded-xl text-white placeholder-slate-400 focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500/20 transition-all duration-200"
                   required
                 />
               </div>
@@ -743,7 +743,7 @@ export function ParkinsonsPredictionForm() {
             disabled={isLoading || Object.values(doctorFormData).some((value) => !value)}
             whileHover={{ scale: 1.02 }}
             whileTap={{ scale: 0.98 }}
-            className="w-full py-4 bg-gradient-to-r from-purple-500 to-indigo-500 text-white font-semibold rounded-xl disabled:opacity-50 disabled:cursor-not-allowed hover:shadow-lg transition-all duration-200 flex items-center justify-center space-x-2"
+            className="w-full py-4 bg-gradient-to-r from-teal-500 to-emerald-600 text-white font-semibold rounded-xl disabled:opacity-50 disabled:cursor-not-allowed hover:shadow-lg transition-all duration-200 flex items-center justify-center space-x-2"
           >
             {isLoading ? (
               <>

--- a/frontend/components/prediction-tabs.tsx
+++ b/frontend/components/prediction-tabs.tsx
@@ -21,8 +21,8 @@ const tabs = [
     id: "parkinsons",
     label: "Parkinson's Disease",
     icon: Brain,
-    color: "from-purple-500 to-indigo-500",
-    glowColor: "shadow-purple-500/25",
+    color: "from-teal-600 to-emerald-800",
+    glowColor: "shadow-teal-500/25",
     description: "Early neurological pattern detection through vocal biomarker analysis and motor assessments",
     features: ["Vocal Analysis", "Motor Symptoms", "Tremor Detection"],
     accuracy: "94%",
@@ -32,8 +32,8 @@ const tabs = [
     id: "diabetes",
     label: "Diabetes",
     icon: Droplet,
-    color: "from-blue-500 to-cyan-500",
-    glowColor: "shadow-blue-500/25",
+    color: "from-cyan-500 to-teal-500",
+    glowColor: "shadow-cyan-500/25",
     description: "Blood glucose prediction and metabolic risk evaluation with comprehensive health metrics",
     features: ["Glucose Levels", "BMI Analysis", "Family History"],
     accuracy: "92%",
@@ -65,13 +65,13 @@ export function PredictionTabs() {
         className="text-center mb-20"
       >
         <div className="inline-flex items-center justify-center mb-6">
-          <div className="flex items-center space-x-3 bg-gradient-to-r from-blue-500/10 to-violet-500/10 border border-blue-500/20 rounded-full px-6 py-3 backdrop-blur-sm">
-            <div className="w-2 h-2 bg-blue-400 rounded-full animate-pulse"></div>
-            <span className="text-sm font-medium text-blue-300">AI-Powered Medical Insights</span>
+          <div className="flex items-center space-x-3 bg-gradient-to-r from-emerald-500/10 to-lime-500/10 border border-emerald-500/20 rounded-full px-6 py-3 backdrop-blur-sm">
+            <div className="w-2 h-2 bg-emerald-400 rounded-full animate-pulse"></div>
+            <span className="text-sm font-medium text-emerald-300">AI-Powered Medical Insights</span>
           </div>
         </div>
         
-        <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold bg-gradient-to-r from-blue-400 via-indigo-400 to-violet-400 bg-clip-text text-transparent mb-6 text-balance">
+        <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold bg-gradient-to-r from-emerald-400 via-teal-400 to-lime-300 bg-clip-text text-transparent mb-6 text-balance">
           Choose Your Health Assessment
         </h2>
         
@@ -87,13 +87,13 @@ export function PredictionTabs() {
             <span>Clinically Validated</span>
           </div>
           <div className="flex items-center space-x-2">
-            <svg className="w-4 h-4 text-blue-400" fill="currentColor" viewBox="0 0 20 20">
+            <svg className="w-4 h-4 text-cyan-400" fill="currentColor" viewBox="0 0 20 20">
               <path d="M13 6a3 3 0 11-6 0 3 3 0 016 0zM18 8a2 2 0 11-4 0 2 2 0 014 0zM14 15a4 4 0 00-8 0v3h8v-3z" />
             </svg>
             <span>Patient & Professional Modes</span>
           </div>
           <div className="flex items-center space-x-2">
-            <svg className="w-4 h-4 text-purple-400" fill="currentColor" viewBox="0 0 20 20">
+            <svg className="w-4 h-4 text-lime-400" fill="currentColor" viewBox="0 0 20 20">
               <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z" clipRule="evenodd" />
             </svg>
             <span>Instant Results</span>
@@ -127,7 +127,7 @@ export function PredictionTabs() {
                 style={{
                   background: "linear-gradient(135deg, rgba(0, 0, 0, 0.6) 0%, rgba(15, 15, 15, 0.8) 100%)",
                   backdropFilter: "blur(20px)",
-                  border: "1px solid rgba(99, 102, 241, 0.1)",
+                  border: "1px solid rgba(255, 255, 255, 0.08)",
                   boxShadow: "0 25px 50px -12px rgba(0, 0, 0, 0.25)",
                 }}
               >
@@ -136,11 +136,11 @@ export function PredictionTabs() {
                   className={`absolute inset-0 bg-gradient-to-br ${tab.color} opacity-5 group-hover:opacity-15 transition-opacity duration-500`}
                 />
 
-                {/* Animated border */}
+                {/* Animated border - neutral wash that lets per-tab gradient show through */}
                 <div
                   className={`absolute inset-0 rounded-3xl opacity-0 group-hover:opacity-100 transition-opacity duration-500`}
                   style={{
-                    background: `linear-gradient(135deg, transparent 0%, rgba(99, 102, 241, 0.1) 50%, transparent 100%)`,
+                    background: `linear-gradient(135deg, transparent 0%, rgba(255, 255, 255, 0.08) 50%, transparent 100%)`,
                     padding: "1px",
                   }}
                 />
@@ -175,7 +175,7 @@ export function PredictionTabs() {
                   {/* Content section */}
                   <div className="flex-1 flex flex-col justify-between">
                     <div>
-                      <h3 className="text-2xl md:text-3xl font-bold text-white mb-4 group-hover:text-transparent group-hover:bg-gradient-to-r group-hover:bg-clip-text group-hover:from-blue-400 group-hover:to-violet-400 transition-all duration-500">
+                      <h3 className="text-2xl md:text-3xl font-bold text-white mb-4 group-hover:text-transparent group-hover:bg-gradient-to-r group-hover:bg-clip-text group-hover:from-emerald-400 group-hover:to-lime-300 transition-all duration-500">
                         {tab.label}
                       </h3>
                       <p className="text-slate-400 group-hover:text-slate-300 transition-colors duration-300 text-pretty leading-relaxed mb-6">
@@ -212,9 +212,9 @@ export function PredictionTabs() {
                         className={`w-3 h-3 rounded-full bg-gradient-to-r ${tab.color} shadow-lg`}
                         animate={{
                           scale: hoveredTab === tab.id ? [1, 1.3, 1] : 1,
-                          boxShadow: hoveredTab === tab.id 
-                            ? ["0 0 0 0 rgba(99, 102, 241, 0.4)", "0 0 0 10px rgba(99, 102, 241, 0)", "0 0 0 0 rgba(99, 102, 241, 0)"]
-                            : "0 0 0 0 rgba(99, 102, 241, 0)",
+                          boxShadow: hoveredTab === tab.id
+                            ? ["0 0 0 0 rgba(16, 185, 129, 0.4)", "0 0 0 10px rgba(16, 185, 129, 0)", "0 0 0 0 rgba(16, 185, 129, 0)"]
+                            : "0 0 0 0 rgba(16, 185, 129, 0)",
                         }}
                         transition={{
                           duration: hoveredTab === tab.id ? 1.5 : 0.3,

--- a/frontend/components/subscription-modal.tsx
+++ b/frontend/components/subscription-modal.tsx
@@ -30,7 +30,7 @@ export function SubscriptionModal({ isOpen, onClose, selectedPlan = 'monthly' }:
         "Export health reports"
       ],
       badge: "Most Flexible",
-      color: "blue",
+      color: "lime",
       buttonText: "Start Free Trial"
     },
     annual: {
@@ -158,7 +158,7 @@ export function SubscriptionModal({ isOpen, onClose, selectedPlan = 'monthly' }:
                   {/* Plan Info */}
                   <div>
                     <div className={`inline-flex items-center px-3 py-1 rounded-full text-xs font-medium mb-4 ${
-                      activePlan === 'monthly' ? 'bg-blue-500/20 text-blue-300' :
+                      activePlan === 'monthly' ? 'bg-lime-500/20 text-lime-300' :
                       activePlan === 'annual' ? 'bg-emerald-500/20 text-emerald-300' :
                       'bg-amber-500/20 text-amber-300'
                     }`}>
@@ -227,13 +227,13 @@ export function SubscriptionModal({ isOpen, onClose, selectedPlan = 'monthly' }:
                       </div>
                     ) : (
                       <div className={`bg-gradient-to-r ${
-                        activePlan === 'monthly' 
-                          ? 'from-blue-500/10 to-purple-500/10 border-blue-400/20' 
+                        activePlan === 'monthly'
+                          ? 'from-lime-500/10 to-emerald-500/10 border-lime-400/20'
                           : 'from-emerald-500/10 to-teal-500/10 border-emerald-400/20'
                       } border rounded-3xl p-8`}>
                         <div className="text-center mb-6">
                           <CreditCard className={`w-16 h-16 mx-auto mb-4 ${
-                            activePlan === 'monthly' ? 'text-blue-400' : 'text-emerald-400'
+                            activePlan === 'monthly' ? 'text-lime-400' : 'text-emerald-400'
                           }`} />
                           <h4 className="text-2xl font-bold text-white mb-2">Ready to get started?</h4>
                           <p className="text-white/60">Join thousands of users improving their health</p>
@@ -243,7 +243,7 @@ export function SubscriptionModal({ isOpen, onClose, selectedPlan = 'monthly' }:
                           onClick={handleSubscribe}
                           className={`w-full font-medium py-4 text-lg ${
                             activePlan === 'monthly'
-                              ? 'bg-blue-500/20 hover:bg-blue-500/30 border border-blue-400/30 text-blue-300'
+                              ? 'bg-lime-500/20 hover:bg-lime-500/30 border border-lime-400/30 text-lime-300'
                               : 'bg-emerald-500/20 hover:bg-emerald-500/30 border border-emerald-400/30 text-emerald-300'
                           }`}
                         >

--- a/frontend/components/user-menu.tsx
+++ b/frontend/components/user-menu.tsx
@@ -197,7 +197,7 @@ export function UserMenu() {
                               {/* Monthly Plan */}
                               <button 
                                 onClick={() => openSubscriptionModal('monthly')}
-                                className="w-full bg-gradient-to-r from-blue-500/20 to-purple-500/20 border border-blue-400/20 rounded-xl p-2.5 sm:p-3 text-left hover:from-blue-500/30 hover:to-purple-500/30 transition-all duration-200"
+                                className="w-full bg-gradient-to-r from-emerald-500/20 to-lime-500/20 border border-emerald-400/20 rounded-xl p-2.5 sm:p-3 text-left hover:from-emerald-500/30 hover:to-lime-500/30 transition-all duration-200"
                               >
                                 <div className="flex justify-between items-center">
                                   <div>
@@ -205,7 +205,7 @@ export function UserMenu() {
                                     <div className="text-xs text-white/60">7-day free trial</div>
                                   </div>
                                   <div className="text-right">
-                                    <div className="text-xs sm:text-sm font-bold text-blue-300">₹50</div>
+                                    <div className="text-xs sm:text-sm font-bold text-lime-300">₹50</div>
                                     <div className="text-xs text-white/60">first month</div>
                                   </div>
                                 </div>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
     "build": "next build",
     "dev": "next dev",
     "lint": "next lint",
-    "start": "next start"
+    "start": "next start",
+    "verify:theme": "node scripts/verify-theme-palette.mjs"
   },
   "dependencies": {
     "@emotion/is-prop-valid": "latest",

--- a/frontend/scripts/verify-theme-palette.mjs
+++ b/frontend/scripts/verify-theme-palette.mjs
@@ -1,0 +1,37 @@
+import fs from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const ROOT = path.join(__dirname, "..")
+const SKIP_DIR_NAMES = new Set([".next", "node_modules", ".git"])
+
+/** @param {string} dir */
+function* walkFiles(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true })
+  for (const e of entries) {
+    const full = path.join(dir, e.name)
+    if (e.isDirectory()) {
+      if (SKIP_DIR_NAMES.has(e.name)) continue
+      yield* walkFiles(full)
+    } else if (/\.(tsx|ts|jsx|js|css|mdx)$/i.test(e.name)) {
+      yield full
+    }
+  }
+}
+
+const NEEDLE = "99, 102, 241"
+const hits = []
+for (const file of walkFiles(ROOT)) {
+  const text = fs.readFileSync(file, "utf8")
+  if (text.includes(NEEDLE)) {
+    hits.push(path.relative(ROOT, file))
+  }
+}
+
+if (hits.length) {
+  console.error(`Forbidden indigo literal "${NEEDLE}" found in:\n${hits.join("\n")}`)
+  process.exit(1)
+}
+console.log("Theme palette guard: no forbidden indigo literal under frontend/.")
+process.exit(0)


### PR DESCRIPTION
This pull request implements the approved theme spec and implementation plan for the Next.js frontend. Light mode uses palette B with emerald as the primary interactive color and lime or chartreuse as the secondary accent. Dark mode uses achromatic OKLCH tokens with neutral glass and neon utilities so global chrome no longer reads as indigo or violet. The floating navbar keeps the existing orange cursor-follow glow and hover behavior while idle borders, shadows, and the logo use neutral silver and emerald-lime gradients.

Marketing surfaces and predict flows are updated so heart stays in the red and rose family, diabetes uses teal and cyan, Parkinson’s uses deep teal and forest tones, and common diseases aligns with emerald and lime. A small Node script `npm run verify:theme` fails the build if the forbidden indigo RGB literal `99, 102, 241` appears under `frontend/`, which helps prevent regressions. Production `npm run build` completes successfully on this branch.

**Testing:** `npm run verify:theme` (pass), `npm run build` in `frontend/` (pass). Manual smoke: theme toggle, home, each predict route, contact, sign-in, and signed-in menu is recommended before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Redesigned the frontend color theme site-wide, replacing blue/purple accents with emerald/teal/lime and neutralized glass/neon effects for a consistent look across pages and components.

* **Documentation**
  * Added comprehensive design spec and implementation plan describing the new theme rules, accessibility checks, and retheming guidance.

* **Chores**
  * Added an automated theme verification script and npm script to enforce palette constraints during CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->